### PR TITLE
Added "Medium-Scale Dancer" article series originally posted to the Dancer mailing list

### DIFF
--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -17,10 +17,10 @@ way to extend beyond this base.
 I say "one way" because Dancer is a policy-free web application
 framework. Its designers purposely avoid making whole classes of design
 decisions for you. That means that Dancer not only doesn’t force you to
-design your app the right way, the framework rarely even gives hints
-about what the right way might be. Dancer prefers to present itself to
-you, the app developer, as a box of tools, which you are free to use as
-you see fit.
+design your app the "right way," by its creators' lights, the framework
+rarely even gives hints about what the right way might be. Dancer
+prefers to present itself to you, the app developer, as a box of tools,
+which you are free to use as you see fit.
 
 The design presented here is working quite well for us, so we think it
 is worthy of emulation, but we do not expect that it will work for all

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -1,0 +1,98 @@
+=head1 Medium-Scale Dancer, Part 1: Modules
+
+=head2 Or: How to Get Beyond Small-Scale in Dancer Application Design
+
+When you generate a Dancer app with C<dancer2 -a App>, you get a very
+nicely structured and useful starting point. As long as your app remains
+fairly small, you can work with this structure as-is clear through to
+completion. In that sense, the generated app is production-ready.
+
+The problem comes when you start getting to thousands of lines of Perl
+code, dozens of view files, and hundreds of routes, stretching the stock
+app design beyond its natural limits. This series of articles gives you
+one way to extend beyond this base.
+
+I say "one way" because Dancer is a policy-free web application
+framework. Its designers purposely avoided making whole classes of
+design decisions for you. That means that Dancer not only doesn’t force
+you to design your app the right way, the framework doesn’t even give
+hints about what the right way might be. It is up to you to use the
+toolset Dancer provides as you see fit.
+
+The design presented here is working quite well for us, so we think it
+is worthy of emulation, but we do not expect that it will work for all
+medium-scale web applications. Think of it as a mutually consistent
+collection of design ideas, rather than a prescription of the One True
+Way to design a Dancer application.
+
+=head2 The Generated Files
+
+When you say C<dancer2 -a App> at the command line, you get a few dozen
+files. Several of these files contain Perl code, but only one of those
+is interesting for the purposes of this article.
+
+We're setting C<bin/app.psgi> and C<public/dispatch.*> aside as
+"uninteresting" here because we recommend that you leave these files
+as-is. None of your app-specific Perl code should go in these files.
+
+We're also ignoring C<Makefile.PL>, since that isn't part of the app
+proper.
+
+That only leaves C<lib/App.pm>. For small-scale apps, simply piling all
+of your Dancer-related app code into this file is just fine. Up to about
+one or two thousand lines of code, you can just use it as-is, for the
+same reason that a thousand-line monolithic Perl script is fine in other
+contexts, too.
+
+=head2 Extending the Stock Scheme
+
+One of the nicest things about Dancer is that the generated startup code
+adds the app's C<lib> directory to the Perl module path. That leads to
+an obvious solution to the problem of too much code in a single file:
+break it out into other C<*.pm> files in the C<lib> directory. But how,
+exactly?
+
+I recommend following the example of CPAN, with a structure like the
+following:
+
+ lib/App.pm                 # your app's main module
+ lib/App/MajorFeature.pm    # implementation of a major app feature
+ lib/App/OtherFeature.pm    # as many feature impl files as you need
+ lib/App/API.pm             # if your app has a REST API, put it here
+ lib/App/Const.pm           # maybe you have some app-wide constants
+ lib/App/Utility.pm         # every big app has a "junk drawer" module
+
+Then in C<lib/App.pm>, you C<use> all of these modules:
+
+ use App::MajorFeature;
+ use App::OtherFeature;
+ use App::API;
+ use App::Const;
+ use App::Utility;
+
+How you design these modules is up to you. The
+L<standard rules|http://stackoverflow.com/questions/410359/how-can-i-learn-to-write-well-structured-programs-in-perl>
+for well-structured Perl application design apply.
+
+There is one Dancer2-specific thing to beware of here, though: you must
+L<set the C<appname> property on the sub-modules|http://advent.perldancer.org/2014/10>. If you
+don't, each sub-module will be considered a separate Dancer2
+application, which puts unwanted barriers between the modules.
+
+(Dancer1 didn't have this requirement, because it didn't have any
+concept of multiple apps within a single Dancer instance.)
+
+When it comes time to break C<lib/App.pm> up into multiple modules, I
+recommend that you move almost all Perl code into one of these modules,
+leaving only application initialization code in the top-level module.
+
+(This, by the way, is why we don't need to modify C<bin/app.psgi>: since
+it pretty much just loads Dancer and then calls C<lib/App.pm>, there is
+no point in splitting app initialization code across the two files. Let
+C<bin/app.psgi> remain a tiny little glue file that exists merely to
+make L<PSGI|http://plackperl.org/> happy.)
+
+Your initial refactoring of C<lib/App.pm> will likely leave all the
+route definitions behind, which is fine, because refactoring the routes
+is the subject of the
+L<next article in this series|http://advent.perldancer.org/2015/4>.

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 1: Modules
 
 =head2 Or: How to Get Beyond Small-Scale in Dancer Application Design

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -37,7 +37,7 @@ We're setting C<bin/app.psgi> and C<public/dispatch.*> aside as
 "uninteresting" here because we recommend that you leave these files
 as-is. None of your app-specific Perl code should go in these files.
 
-We're also ignoring C<Makefile.PL>, since that isn't part of the app
+We're also ignoring C<Makefile.PL> since that isn't part of the app
 proper.
 
 That only leaves C<lib/App.pm>. For small-scale apps, simply piling all
@@ -81,7 +81,7 @@ L<set the C<appname> property on the sub-modules|http://advent.perldancer.org/20
 don't, each sub-module will be considered a separate Dancer2
 application, which puts unwanted barriers between the modules.
 
-(Dancer1 didn't have this requirement, because it didn't have any
+(Dancer1 didn't have this requirement because it didn't have any
 concept of multiple apps within a single Dancer instance.)
 
 When it comes time to break C<lib/App.pm> up into multiple modules, I
@@ -95,6 +95,6 @@ C<bin/app.psgi> remain a tiny little glue file that exists merely to
 make L<PSGI|http://plackperl.org/> happy.)
 
 Your initial refactoring of C<lib/App.pm> will likely leave all the
-route definitions behind, which is fine, because refactoring the routes
+route definitions behind, which is fine because refactoring the routes
 is the subject of the
 L<next article in this series|http://advent.perldancer.org/2015/4>.

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -19,8 +19,8 @@ framework. Its designers purposely avoid making whole classes of design
 decisions for you. That means that Dancer not only doesn’t force you to
 design your app the "right way," by its creators' lights, the framework
 rarely even gives hints about what the right way might be. Dancer
-prefers to present itself to you, the app developer, as a box of tools,
-which you are free to use as you see fit.
+prefers to present itself as a box of tools, which you are free to use
+as you see fit.
 
 The design presented here is working quite well for us, so we think it
 is worthy of emulation, but we do not expect that it will work for all

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -58,20 +58,20 @@ exactly?
 I recommend following the example of CPAN, with a structure like the
 following:
 
- lib/App.pm                 # your app's main module
- lib/App/MajorFeature.pm    # implementation of a major app feature
- lib/App/OtherFeature.pm    # as many feature impl files as you need
- lib/App/API.pm             # if your app has a REST API, put it here
- lib/App/Const.pm           # maybe you have some app-wide constants
- lib/App/Utility.pm         # every big app has a "junk drawer" module
+    lib/App.pm                 # your app's main module
+    lib/App/MajorFeature.pm    # implementation of a major app feature
+    lib/App/OtherFeature.pm    # as many feature impl files as you need
+    lib/App/API.pm             # if your app has a REST API, put it here
+    lib/App/Const.pm           # maybe you have some app-wide constants
+    lib/App/Utility.pm         # every big app has a "junk drawer" module
 
 Then in C<lib/App.pm>, you C<use> all of these modules:
 
- use App::MajorFeature;
- use App::OtherFeature;
- use App::API;
- use App::Const;
- use App::Utility;
+    use App::MajorFeature;
+    use App::OtherFeature;
+    use App::API;
+    use App::Const;
+    use App::Utility;
 
 How you design these modules is up to you. The
 L<standard rules|http://stackoverflow.com/questions/410359/how-can-i-learn-to-write-well-structured-programs-in-perl>

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -17,9 +17,10 @@ way to extend beyond this base.
 I say "one way" because Dancer is a policy-free web application
 framework. Its designers purposely avoid making whole classes of design
 decisions for you. That means that Dancer not only doesn’t force you to
-design your app the right way, the framework doesn’t even give hints
-about what the right way might be. It is up to you to use the toolset
-Dancer provides as you see fit.
+design your app the right way, the framework rarely even gives hints
+about what the right way might be. Dancer prefers to present itself to
+you, the app developer, as a box of tools, which you are free to use as
+you see fit.
 
 The design presented here is working quite well for us, so we think it
 is worthy of emulation, but we do not expect that it will work for all

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -9,10 +9,10 @@ nicely structured and useful starting point. As long as your app remains
 fairly small, you can work with this structure as-is clear through to
 completion. In that sense, the generated app is production-ready.
 
-The problem comes when you start getting to thousands of lines of Perl
-code, dozens of view files, and hundreds of routes, stretching the stock
-app design beyond its natural limits. This series of articles gives you
-one way to extend beyond this base.
+The problem comes when you get to thousands of lines of Perl code,
+dozens of view files, and dozens of routes, stretching the stock app
+design beyond its natural limits. This series of articles gives you one
+way to extend beyond this base.
 
 I say "one way" because Dancer is a policy-free web application
 framework. Its designers purposely avoided making whole classes of

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -99,3 +99,8 @@ Your initial refactoring of C<lib/App.pm> will likely leave all the
 route definitions behind, which is fine because refactoring the routes
 is the subject of the
 L<next article in this series|http://advent.perldancer.org/2015/4>.
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -10,7 +10,7 @@ fairly small, you can work with this structure as-is clear through to
 completion. In that sense, the generated app is production-ready.
 
 The problem comes when you get to thousands of lines of Perl code,
-dozens of view files, and dozens of routes, stretching the stock app
+dozens of templates, and dozens of routes, stretching the stock app
 design beyond its natural limits. This series of articles gives you one
 way to extend beyond this base.
 

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -38,8 +38,8 @@ We're setting C<bin/app.psgi> and C<public/dispatch.*> aside as
 "uninteresting" here because we recommend that you leave these files
 as-is. None of your app-specific Perl code should go in these files.
 
-We're also ignoring C<Makefile.PL> since that isn't part of the app
-proper.
+We're also ignoring C<Makefile.PL> since it's part of the app's build
+system, not part of the app proper.
 
 That only leaves C<lib/App.pm>. For small-scale apps, simply piling all
 of your Dancer-related app code into this file is just fine. Up to about

--- a/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
+++ b/danceradvent/public/articles/2015/3-medium-scale-part-1.pod
@@ -15,11 +15,11 @@ design beyond its natural limits. This series of articles gives you one
 way to extend beyond this base.
 
 I say "one way" because Dancer is a policy-free web application
-framework. Its designers purposely avoided making whole classes of
-design decisions for you. That means that Dancer not only doesn’t force
-you to design your app the right way, the framework doesn’t even give
-hints about what the right way might be. It is up to you to use the
-toolset Dancer provides as you see fit.
+framework. Its designers purposely avoid making whole classes of design
+decisions for you. That means that Dancer not only doesn’t force you to
+design your app the right way, the framework doesn’t even give hints
+about what the right way might be. It is up to you to use the toolset
+Dancer provides as you see fit.
 
 The design presented here is working quite well for us, so we think it
 is worthy of emulation, but we do not expect that it will work for all

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -43,14 +43,18 @@ implementing each route handler should move to C<lib/App/*.pm>. Ideally,
 each route handler body should do nothing more than call a function in
 one of these modules:
 
- get  '/mf'                => sub { App::MajorFeature::retrieve; };
- get  '/mf/subfeature'     => sub { App::MajorFeature::sub_feature; };
- post '/mf/subfeature'     => sub { App::MajorFeature::add; };
- put  '/mf/subfeature'     => sub { App::MajorFeature::modify; };
- del  '/mf/subfeature/:id' => sub { App::MajorFeature::remove; };
+ get  '/mf'                => \&App::MajorFeature::retrieve;
+ get  '/mf/subfeature'     => \&App::MajorFeature::sub_feature;
+ post '/mf/subfeature'     => \&App::MajorFeature::add;
+ put  '/mf/subfeature'     => \&App::MajorFeature::modify;
+ del  '/mf/subfeature/:id' => \&App::MajorFeature::remove;
 
-If that still looks like a bit of a mess to you, don't worry, we can
-factor out the redundancy in two stages.
+Notice that by moving all of the code for each route handler into a
+function in one of our module files, we can replace the inline anonymous
+function references with explicit fully-qualified function references.
+
+There's a fair bit of redundancy in that code, which we'll compress out
+in two stages.
 
 First, Dancer has the awesome
 L<C<prefix>|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod#prefix>
@@ -58,12 +62,12 @@ feature, which lets us express the URL hierarchy directly in the code,
 without repeating elements of the URL:
 
  prefix '/mf' => sub {
-     get '/' => sub { App::MajorFeature::retrieve; };
+     get '/' => \&App::MajorFeature::retrieve;
      prefix '/subfeature' => sub {
-         get  '/'    => sub { App::MajorFeature::sub_feature; };
-         post '/'    => sub { App::MajorFeature::add; };
-         put  '/'    => sub { App::MajorFeature::modify; };
-         del  '/:id' => sub { App::MajorFeature::remove; };
+         get  '/'    => \&App::MajorFeature::sub_feature;
+         post '/'    => \&App::MajorFeature::add;
+         put  '/'    => \&App::MajorFeature::modify;
+         del  '/:id' => \&App::MajorFeature::remove;
      };
  };
 
@@ -89,12 +93,12 @@ Therefore, we can move all of the route definitions above from
 C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
 
  prefix '/mf' => sub {
-     get '/' => sub { retrieve; };
+     get '/' => \&retrieve;
      prefix '/subfeature' => sub {
-         get  '/'    => sub { sub_feature; };
-         post '/'    => sub { add; };
-         put  '/'    => sub { modify); };
-         del  '/:id' => sub { remove; };
+         get  '/'    => \&sub_feature;
+         post '/'    => \&add;
+         put  '/'    => \&modify;
+         del  '/:id' => \&remove;
      };
  };
 

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -43,35 +43,14 @@ implementing each route handler should move to C<lib/App/*.pm>. Ideally,
 each route handler body should do nothing more than call a function in
 one of these modules:
 
- get  '/mf'                => sub { App::MajorFeature::retrieve(context); };
- get  '/mf/subfeature'     => sub { App::MajorFeature::sub_feature(context); };
- post '/mf/subfeature'     => sub { App::MajorFeature::add(context); };
- put  '/mf/subfeature'     => sub { App::MajorFeature::modify(context); };
- del  '/mf/subfeature/:id' => sub { App::MajorFeature::remove(context); };
+ get  '/mf'                => sub { App::MajorFeature::retrieve; };
+ get  '/mf/subfeature'     => sub { App::MajorFeature::sub_feature; };
+ post '/mf/subfeature'     => sub { App::MajorFeature::add; };
+ put  '/mf/subfeature'     => sub { App::MajorFeature::modify; };
+ del  '/mf/subfeature/:id' => sub { App::MajorFeature::remove; };
 
-If that still looks like a bit of a mess to you, don't worry, we'll 
-continue to improve it as we go along.
-
-The C<context()> function that I call from each of those route handlers
-is a small helper that I define at global scope within the app:
-
- sub context {
-     return {
-         config  => config(),
-         request => request(),
-         session => session(),
-         dbconn  => App::Utility::get_db_conn(),
-         etc     => ...
-     };
- }
-
-It just bundles up a bunch of Dancer objects into a hash for you,
-possibly along with some app-specific objects that are widely used
-within your app. I find this convenient, but perhaps you prefer to use
-the Dancer DSL to access each of these objects directly instead.
-
-The URL scheme defined above is quite redundant. We can factor out that
-redundancy in two stages.
+If that still looks like a bit of a mess to you, don't worry, we can
+factor out the redundancy in two stages.
 
 First, Dancer has the awesome
 L<C<prefix>|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod#prefix>
@@ -79,22 +58,18 @@ feature, which lets us express the URL hierarchy directly in the code,
 without repeating elements of the URL:
 
  prefix '/mf' => sub {
-     get '/' => sub { App::MajorFeature::retrieve(context); };
+     get '/' => sub { App::MajorFeature::retrieve; };
      prefix '/subfeature' => sub {
-         get  '/'    => sub { App::MajorFeature::sub_feature(context); };
-         post '/'    => sub { App::MajorFeature::add(context); };
-         put  '/'    => sub { App::MajorFeature::modify(context); };
-         del  '/:id' => sub { App::MajorFeature::remove(context); };
+         get  '/'    => sub { App::MajorFeature::sub_feature; };
+         post '/'    => sub { App::MajorFeature::add; };
+         put  '/'    => sub { App::MajorFeature::modify; };
+         del  '/:id' => sub { App::MajorFeature::remove; };
      };
  };
 
-Factoring out the C</mf> part was a net loss of 1 character per route
-with our 4-space indents, but factoring out C</subfeature> saved us a
-net 6 characters per route, which really helps make the code easier to
-read.
-
-Rewriting your URL handlers this way will help us greatly later in this
-series of articles.
+As you can see, this makes the overall code narrower, because we're not
+repeating outselves as much. This move toward using C<prefix> will help
+considerably later in this series of articles.
 
 A second excellent feature of Dancer lets us shorten those lines of code
 still further.
@@ -114,44 +89,17 @@ Therefore, we can move all of the route definitions above from
 C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
 
  prefix '/mf' => sub {
-     get '/' => sub { retrieve(context); };
+     get '/' => sub { retrieve; };
      prefix '/subfeature' => sub {
-         get  '/'    => sub { sub_feature(context); };
-         post '/'    => sub { add(context); };
-         put  '/'    => sub { modify(context); };
-         del  '/:id' => sub { remove(context); };
+         get  '/'    => sub { sub_feature; };
+         post '/'    => sub { add; };
+         put  '/'    => sub { modify); };
+         del  '/:id' => sub { remove; };
      };
  };
 
 Now all the function calls are made within the C<App::MajorFeature>
 module, so we don't need to qualify them.
-
-If you are using my C<context()> idea, you will have to move it out of
-C<lib/App.pm>, such as into the C<App::Utility> module, exported by
-default:
-
- package App::Utility {
-     use Dancer2 appname => 'App';
- 
-     require Exporter;
-     use base qw(Exporter);
-     our @EXPORT = qw(context);
- 
-     sub get_db_conn {
-         # do something useful here;
-         # not exported, since context->{dbconn} holds our return value
-     }
- 
-     sub context {
-         return {
-             config  => config(),
-             request => request(),
-             session => session(),
-             dbconn  => get_db_conn(),
-             etc     => ...
-         };
-     }
- }
 
 Having done all this, all that's left behind in C<lib/App.pm> is Dancer
 startup and other initialization code, such as hook definitions, as is

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -112,7 +112,7 @@ startup and other initialization code, such as hook definitions, as is
 appropriate for the app's top-level module.
 
 The bulk of the application's code is now collected into a set of
-tightly-scoped modules. These modules should also be largely decoupled,
+tightly-scoped modules. These modules should also be largely decoupled
 since only Dancer needs to know how to call into them, and you told it
 how from the module itself, by defining routes. Beautiful.
 

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -20,36 +20,36 @@ If you extend the generated C<lib/App.pm> file by following the simplest
 examples from the Dancer documentation, you might have a mess that looks
 something like this:
 
- get '/mf' => sub {
-     # Lots of Perl code to return the top-level MajorFeature view
- };
+    get '/mf' => sub {
+        # Lots of Perl code to return the top-level MajorFeature view
+    };
 
- get '/mf/subfeature' => sub {
-     # Implementation of a sub-feature of MajorFeature
- };
+    get '/mf/subfeature' => sub {
+        # Implementation of a sub-feature of MajorFeature
+    };
 
- post '/mf/subfeature' => sub {
-     # Maybe you need a way to add new subfeature objects
- };
+    post '/mf/subfeature' => sub {
+        # Maybe you need a way to add new subfeature objects
+    };
 
- put '/mf/subfeature' => sub {
-     # And maybe also a way to edit existing subfeature objects
- };
+    put '/mf/subfeature' => sub {
+        # And maybe also a way to edit existing subfeature objects
+    };
 
- del '/mf/subfeature/:id' => sub {
-     # And a way to delete them, too
- };
+    del '/mf/subfeature/:id' => sub {
+        # And a way to delete them, too
+    };
 
 The first thing to fix here is that almost all of the Perl code
 implementing each route handler should move to C<lib/App/*.pm>. Ideally,
 each route handler body should do nothing more than call a function in
 one of these modules:
 
- get  '/mf'                => \&App::MajorFeature::retrieve;
- get  '/mf/subfeature'     => \&App::MajorFeature::sub_feature;
- post '/mf/subfeature'     => \&App::MajorFeature::add;
- put  '/mf/subfeature'     => \&App::MajorFeature::modify;
- del  '/mf/subfeature/:id' => \&App::MajorFeature::remove;
+    get  '/mf'                => \&App::MajorFeature::retrieve;
+    get  '/mf/subfeature'     => \&App::MajorFeature::sub_feature;
+    post '/mf/subfeature'     => \&App::MajorFeature::add;
+    put  '/mf/subfeature'     => \&App::MajorFeature::modify;
+    del  '/mf/subfeature/:id' => \&App::MajorFeature::remove;
 
 Notice that by moving all of the code for each route handler into a
 function in one of our module files, we can replace the inline anonymous
@@ -63,15 +63,15 @@ L<C<prefix>|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod
 feature, which lets us express the URL hierarchy directly in the code,
 without repeating elements of the URL:
 
- prefix '/mf' => sub {
-     get '' => \&App::MajorFeature::retrieve;
-     prefix '/subfeature' => sub {
-         get  ''     => \&App::MajorFeature::sub_feature;
-         post ''     => \&App::MajorFeature::add;
-         put  ''     => \&App::MajorFeature::modify;
-         del  '/:id' => \&App::MajorFeature::remove;
-     };
- };
+    prefix '/mf' => sub {
+        get '' => \&App::MajorFeature::retrieve;
+        prefix '/subfeature' => sub {
+            get  ''     => \&App::MajorFeature::sub_feature;
+            post ''     => \&App::MajorFeature::add;
+            put  ''     => \&App::MajorFeature::modify;
+            del  '/:id' => \&App::MajorFeature::remove;
+        };
+    };
 
 As you can see, this makes the overall code narrower, because we're not
 repeating ourselves as much. This move toward using C<prefix> will help
@@ -94,15 +94,15 @@ that any code at global scope within these modules also runs at startup.
 Therefore, we can move all of the route definitions above from
 C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
 
- prefix '/mf' => sub {
-     get '' => \&retrieve;
-     prefix '/subfeature' => sub {
-         get  ''     => \&sub_feature;
-         post ''     => \&add;
-         put  ''     => \&modify;
-         del  '/:id' => \&remove;
-     };
- };
+    prefix '/mf' => sub {
+        get '' => \&retrieve;
+        prefix '/subfeature' => sub {
+            get  ''     => \&sub_feature;
+            post ''     => \&add;
+            put  ''     => \&modify;
+            del  '/:id' => \&remove;
+        };
+    };
 
 Now all the function calls are made within the C<App::MajorFeature>
 module, so we don't need to qualify them.

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -126,3 +126,8 @@ how from the module itself, by defining routes. Beautiful.
 In the L<next part of this series|http://advent.perldancer.org/2015/5>,
 we will consider how this application restructuring affects the way we
 arrange our template files on disk.
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 2: Route Definitions
 
 By the time a Dancer app grows large enough that you want to start

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -64,11 +64,11 @@ feature, which lets us express the URL hierarchy directly in the code,
 without repeating elements of the URL:
 
  prefix '/mf' => sub {
-     get '/' => \&App::MajorFeature::retrieve;
+     get '' => \&App::MajorFeature::retrieve;
      prefix '/subfeature' => sub {
-         get  '/'    => \&App::MajorFeature::sub_feature;
-         post '/'    => \&App::MajorFeature::add;
-         put  '/'    => \&App::MajorFeature::modify;
+         get  ''     => \&App::MajorFeature::sub_feature;
+         post ''     => \&App::MajorFeature::add;
+         put  ''     => \&App::MajorFeature::modify;
          del  '/:id' => \&App::MajorFeature::remove;
      };
  };
@@ -95,11 +95,11 @@ Therefore, we can move all of the route definitions above from
 C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
 
  prefix '/mf' => sub {
-     get '/' => \&retrieve;
+     get '' => \&retrieve;
      prefix '/subfeature' => sub {
-         get  '/'    => \&sub_feature;
-         post '/'    => \&add;
-         put  '/'    => \&modify;
+         get  ''     => \&sub_feature;
+         post ''     => \&add;
+         put  ''     => \&modify;
          del  '/:id' => \&remove;
      };
  };

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -13,8 +13,8 @@ If you structured your app in the way recommended in the previous
 article, each major feature of your web app is now in its own Perl
 module. That Perl module's name likely corresponds to some part of your
 app's URL scheme. Let's say you're exposing the features of
-C<App::MajorFeature> as C</mf> in URLs, with sub-features underneath
-that.
+C<App::MajorFeature> as C</mf> in URLs, with sub-features defined in
+C<App::MajorFeature::SubFeature> and exposed via C</mf/sf> routes.
 
 If you extend the generated C<lib/App.pm> file by following the simplest
 examples from the Dancer documentation, you might have a mess that looks
@@ -24,19 +24,19 @@ something like this:
         # Lots of Perl code to return the top-level MajorFeature view
     };
 
-    get '/mf/subfeature' => sub {
+    get '/mf/sf' => sub {
         # Implementation of a sub-feature of MajorFeature
     };
 
-    post '/mf/subfeature' => sub {
+    post '/mf/sf' => sub {
         # Maybe you need a way to add new subfeature objects
     };
 
-    put '/mf/subfeature' => sub {
+    put '/mf/sf' => sub {
         # And maybe also a way to edit existing subfeature objects
     };
 
-    del '/mf/subfeature/:id' => sub {
+    del '/mf/sf/:id' => sub {
         # And a way to delete them, too
     };
 
@@ -45,11 +45,11 @@ implementing each route handler should move to C<lib/App/*.pm>. Ideally,
 each route handler body should do nothing more than call a function in
 one of these modules:
 
-    get  '/mf'                => \&App::MajorFeature::retrieve;
-    get  '/mf/subfeature'     => \&App::MajorFeature::sub_feature;
-    post '/mf/subfeature'     => \&App::MajorFeature::add;
-    put  '/mf/subfeature'     => \&App::MajorFeature::modify;
-    del  '/mf/subfeature/:id' => \&App::MajorFeature::remove;
+    get  '/mf'        => \&App::MajorFeature::retrieve;
+    get  '/mf/sf'     => \&App::MajorFeature::sub_feature;
+    post '/mf/sf'     => \&App::MajorFeature::add;
+    put  '/mf/sf'     => \&App::MajorFeature::modify;
+    del  '/mf/sf/:id' => \&App::MajorFeature::remove;
 
 Notice that by moving all of the code for each route handler into a
 function in one of our module files, we can replace the inline anonymous
@@ -65,7 +65,7 @@ without repeating elements of the URL:
 
     prefix '/mf' => sub {
         get '' => \&App::MajorFeature::retrieve;
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             get  ''     => \&App::MajorFeature::sub_feature;
             post ''     => \&App::MajorFeature::add;
             put  ''     => \&App::MajorFeature::modify;
@@ -96,7 +96,7 @@ C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
 
     prefix '/mf' => sub {
         get '' => \&retrieve;
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             get  ''     => \&sub_feature;
             post ''     => \&add;
             put  ''     => \&modify;

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -74,7 +74,7 @@ without repeating elements of the URL:
  };
 
 As you can see, this makes the overall code narrower, because we're not
-repeating outselves as much. This move toward using C<prefix> will help
+repeating ourselves as much. This move toward using C<prefix> will help
 considerably later in this series of articles.
 
 A second excellent feature of Dancer lets us shorten those lines of code

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -1,0 +1,167 @@
+=head1 Medium-Scale Dancer, Part 2: Route Definitions
+
+By the time a Dancer app grows large enough that you want to start
+breaking it up into multiple Perl modules, as in the
+L<previous article in this series|http://advent.perldancer.org/2015/3>,
+you've probably also defined enough routes that you're starting to have
+problems managing them all. Just as with the Perl code, Dancer lets us
+break up the monolithic route definition set, too.
+
+If you structured your app in the way recommended in the previous
+article, each major feature of your web app is now in its own Perl
+module. That Perl module's name likely corresponds to some part of your
+app's URL scheme. Let's say you're exposing the features of
+C<App::MajorFeature> as C</mf> in URLs, with sub-features underneath
+that.
+
+If you extend the generated C<lib/App.pm> file by following the simplest
+examples from the Dancer documentation, you might have a mess that looks
+something like this:
+
+ get '/mf' => sub {
+     # Lots of Perl code to return the top-level MajorFeature view
+ };
+
+ get '/mf/subfeature' => sub {
+     # Implementation of a sub-feature of MajorFeature
+ };
+
+ post '/mf/subfeature' => sub {
+     # Maybe you need a way to add new subfeature objects
+ };
+
+ put '/mf/subfeature' => sub {
+     # And maybe also a way to edit existing subfeature objects
+ };
+
+ del '/mf/subfeature/:id' => sub {
+     # And a way to delete them, too
+ };
+
+The first thing to fix here is that almost all of the Perl code
+implementing each route handler should move to C<lib/App/*.pm>. Ideally,
+each route handler body should do nothing more than call a function in
+one of these modules:
+
+ get  '/mf'                => sub { App::MajorFeature::retrieve(context); };
+ get  '/mf/subfeature'     => sub { App::MajorFeature::sub_feature(context); };
+ post '/mf/subfeature'     => sub { App::MajorFeature::add(context); };
+ put  '/mf/subfeature'     => sub { App::MajorFeature::modify(context); };
+ del  '/mf/subfeature/:id' => sub { App::MajorFeature::remove(context); };
+
+If that still looks like a bit of a mess to you, don't worry, we'll 
+continue to improve it as we go along.
+
+The C<context()> function that I call from each of those route handlers
+is a small helper that I define at global scope within the app:
+
+ sub context {
+     return {
+         config  => config(),
+         request => request(),
+         session => session(),
+         dbconn  => App::Utility::get_db_conn(),
+         etc     => ...
+     };
+ }
+
+It just bundles up a bunch of Dancer objects into a hash for you,
+possibly along with some app-specific objects that are widely used
+within your app. I find this convenient, but perhaps you prefer to use
+the Dancer DSL to access each of these objects directly instead.
+
+The URL scheme defined above is quite redundant. We can factor out that
+redundancy in two stages.
+
+First, Dancer has the awesome
+L<C<prefix>|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod#prefix>
+feature, which lets us express the URL hierarchy directly in the code,
+without repeating elements of the URL:
+
+ prefix '/mf' => sub {
+     get '/' => sub { App::MajorFeature::retrieve(context); };
+     prefix '/subfeature' => sub {
+         get  '/'    => sub { App::MajorFeature::sub_feature(context); };
+         post '/'    => sub { App::MajorFeature::add(context); };
+         put  '/'    => sub { App::MajorFeature::modify(context); };
+         del  '/:id' => sub { App::MajorFeature::remove(context); };
+     };
+ };
+
+Factoring out the C</mf> part was a net loss of 1 character per route
+with our 4-space indents, but factoring out C</subfeature> saved us a
+net 6 characters per route, which really helps make the code easier to
+read.
+
+Rewriting your URL handlers this way will help us greatly later in this
+series of articles.
+
+A second excellent feature of Dancer lets us shorten those lines of code
+still further.
+
+So far, we've been using explicitly-qualified function names. This is
+because we want to use short function names within the modules (e.g.
+C<retrieve()>) without causing namespace collisions by exporting all of
+the functions. But in fact, there is actually no need to expose the API
+of your modules outside the module itself. Dancer doesn't care I<where>
+you define the route handlers, just that they're all defined by the time
+your caller wants to use them. In the previous part of this article
+series, we said C<use App::MajorFeature> and such within C<lib/App.pm>,
+so every one of our app's modules gets executed on startup. This means
+that any code at global scope within these modules also runs at startup.
+
+Therefore, we can move all of the route definitions above from
+C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
+
+ prefix '/mf' => sub {
+     get '/' => sub { retrieve(context); };
+     prefix '/subfeature' => sub {
+         get  '/'    => sub { sub_feature(context); };
+         post '/'    => sub { add(context); };
+         put  '/'    => sub { modify(context); };
+         del  '/:id' => sub { remove(context); };
+     };
+ };
+
+Now all the function calls are made within the C<App::MajorFeature>
+module, so we don't need to qualify them.
+
+If you are using my C<context()> idea, you will have to move it out of
+C<lib/App.pm>, such as into the C<App::Utility> module, exported by
+default:
+
+ package App::Utility {
+     use Dancer2 appname => 'App';
+ 
+     require Exporter;
+     use base qw(Exporter);
+     our @EXPORT = qw(context);
+ 
+     sub get_db_conn {
+         # do something useful here;
+         # not exported, since context->{dbconn} holds our return value
+     }
+ 
+     sub context {
+         return {
+             config  => config(),
+             request => request(),
+             session => session(),
+             dbconn  => get_db_conn(),
+             etc     => ...
+         };
+     }
+ }
+
+Having done all this, all that's left behind in C<lib/App.pm> is Dancer
+startup and other initialization code, such as hook definitions, as is
+appropriate for the app's top-level module.
+
+The bulk of the application's code is now collected into a set of
+tightly-scoped modules. These modules should also be largely decoupled,
+since only Dancer needs to know how to call into them, and you told it
+how from the module itself, by defining routes. Beautiful.
+
+In the L<next part of this series|http://advent.perldancer.org/2015/5>,
+we will consider how this application restructuring affects the way we
+arrange our view files.

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -46,10 +46,10 @@ each route handler body should do nothing more than call a function in
 one of these modules:
 
     get  '/mf'        => \&App::MajorFeature::retrieve;
-    get  '/mf/sf'     => \&App::MajorFeature::sub_feature;
-    post '/mf/sf'     => \&App::MajorFeature::add;
-    put  '/mf/sf'     => \&App::MajorFeature::modify;
-    del  '/mf/sf/:id' => \&App::MajorFeature::remove;
+    get  '/mf/sf'     => \&App::MajorFeature::SubFeature::retreive;
+    post '/mf/sf'     => \&App::MajorFeature::SubFeature::add;
+    put  '/mf/sf'     => \&App::MajorFeature::SubFeature::modify;
+    del  '/mf/sf/:id' => \&App::MajorFeature::SubFeature::remove;
 
 Notice that by moving all of the code for each route handler into a
 function in one of our module files, we can replace the inline anonymous
@@ -66,10 +66,10 @@ without repeating elements of the URL:
     prefix '/mf' => sub {
         get '' => \&App::MajorFeature::retrieve;
         prefix '/sf' => sub {
-            get  ''     => \&App::MajorFeature::sub_feature;
-            post ''     => \&App::MajorFeature::add;
-            put  ''     => \&App::MajorFeature::modify;
-            del  '/:id' => \&App::MajorFeature::remove;
+            get  ''     => \&App::MajorFeature::SubFeature::retreive;
+            post ''     => \&App::MajorFeature::SubFeature::add;
+            put  ''     => \&App::MajorFeature::SubFeature::modify;
+            del  '/:id' => \&App::MajorFeature::SubFeature::remove;
         };
     };
 
@@ -92,20 +92,27 @@ so every one of our app's modules gets executed on startup. This means
 that any code at global scope within these modules also runs at startup.
 
 Therefore, we can move all of the route definitions above from
-C<lib/App.pm> to the end of C<lib/App/MajorFeature.pm>:
+C<lib/App.pm> to the end of the module where we define each route's
+handler. That is, the tail end of C<lib/App/MajorFeature.pm> says:
 
     prefix '/mf' => sub {
         get '' => \&retrieve;
+    };
+
+...and the tail end of C<lib/App/MajorFeature/SubFeature.pm> says:
+
+    prefix '/mf' => sub {
         prefix '/sf' => sub {
-            get  ''     => \&sub_feature;
+            get  ''     => \&retreive;
             post ''     => \&add;
             put  ''     => \&modify;
             del  '/:id' => \&remove;
         };
     };
 
-Now all the function calls are made within the C<App::MajorFeature>
-module, so we don't need to qualify them.
+The route definitions are much shorter now because they refer to
+module-local functions defined above the route definitions, so the code
+references don't need to be fully-qualified.
 
 Having done all this, all that's left behind in C<lib/App.pm> is Dancer
 startup and other initialization code, such as hook definitions, as is

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -53,7 +53,7 @@ one of these modules:
 
 Notice that by moving all of the code for each route handler into a
 function in one of our module files, we can replace the inline anonymous
-function references with explicit fully-qualified function references.
+function references with explicit fully qualified function references.
 
 There's a fair bit of redundancy in that code, which we'll compress out
 in two stages.

--- a/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
+++ b/danceradvent/public/articles/2015/4-medium-scale-part-2.pod
@@ -118,4 +118,4 @@ how from the module itself, by defining routes. Beautiful.
 
 In the L<next part of this series|http://advent.perldancer.org/2015/5>,
 we will consider how this application restructuring affects the way we
-arrange our view files.
+arrange our template files on disk.

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 3: Views
 
 The

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -9,9 +9,10 @@ broke the monolithic C<lib/App.pm> file up into a series of Perl
 modules, each focused on a functional centroid of the application.
 
 If we describe the default C<lib/App.pm> file as monolithic, then we
-might get away with describing the view files as polylithic because we
-do not need to break the view files up; they naturally map to web pages,
-so the app's URL scheme effectively keeps them separated by purpose.
+might get away with describing the app's C<views/> tree as "polylithic"
+because there is no monolith to break up; the template files in this
+subtree naturally map to web pages, so the app's URL scheme effectively
+keeps them separated by purpose.
 
 Although we will not start this part of the series needing to break up
 an overly large file, I can pass along some tips that might cause you to
@@ -50,9 +51,9 @@ C<*.js> files, rather than put it inline in the HTML file.
 
 There is nothing about the way Dancer works that enforces or even
 encourages any particular C<views/*> file naming scheme. Thus this tip:
-for your own sanity, I recommend that you name your view files after the
-corresponding route. The Dancer scheme corresponding to the above PHP
-scheme might look something like this:
+for your own sanity, I recommend that you name your template files after
+the corresponding route. The Dancer scheme corresponding to the above
+PHP scheme might look something like this:
 
  views/top.tt
  views/mf/top.tt
@@ -61,15 +62,15 @@ scheme might look something like this:
  views/mf/subfeature/put.tt
  views/mf/subfeature/delete.tt
 
-This scheme maps Dancer routes 1:1 to view files, using a naming scheme
-that is easy to remember since it's nearly identical to the URL scheme.
-It's so simple a mapping that you could write a Perl one-liner to do the
-transform. Restricting yourself to a simple naming convention removes a
-whole class of details that you have to keep in mind while working on
-your web app; you don't have to guess where the view file for a given
-route handler lives, you already I<know> where it lives. You will
-quickly rediscover this simple mapping years from now when you have to
-work on the web app again.
+This scheme maps Dancer routes 1:1 to template files, using a naming
+scheme that is easy to remember since it's nearly identical to the URL
+scheme.  It's so simple a mapping that you could write a Perl one-liner
+to do the transform. Restricting yourself to a simple naming convention
+removes a whole class of details that you have to keep in mind while
+working on your web app; you don't have to guess where the template file
+for a given route handler lives, you already I<know> where it lives. You
+will quickly rediscover this simple mapping years from now when you have
+to work on the web app again.
 
 This naming scheme is very much a suggestion, rather than a
 prescription. For one thing, you may find that the C<DELETE
@@ -84,8 +85,8 @@ necessarily to follow the one I've laid out above.
 =head2 Factor Common UI Elements Out
 
 If you reuse a particular UI element across different parts of your web
-app, put its view file into a special view directory. I use
-C<views/parts> for this.
+app, put its template file into a special subdirectory of C<views/>. I
+use C<views/parts> for this.
 
 If you have an HTML fragment page that is incorporated into your web app
 dynamically on the client side via Ajax, you will need a corresponding

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -103,7 +103,7 @@ Then in C<lib/App/Parts/Component.pm>:
  }
  
  prefix '/parts' => sub {
-     get 'component' => sub { _get(); };
+     get 'component' => \&_get;
  };
 
 I chose the naming scheme for the function carefully. I want to be able
@@ -139,8 +139,8 @@ in it:
  }
  
  prefix '/mf' => sub {
-     get '/' => sub { Get; };
-     # other route handlers here <br />
+     get '/' => \&Get;
+     # other route handlers here
  };
 
 Then within C<views/mf/top.tt>, you can reference C<$component> to

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -24,9 +24,9 @@ Older web frameworks like PHP, ASP, and JSP define the web app's URL
 structure in the file system. The route scheme defined in the previous
 part of this article series would look like this in PHP:
 
- index.php
- mf/index.php
- mf/subfeature/index.php
+    index.php
+    mf/index.php
+    mf/subfeature/index.php
 
 The view code — HTML and inline JavaScript — is intermixed with the
 server-side code in the same file. Worse, single files like
@@ -55,12 +55,12 @@ for your own sanity, I recommend that you name your template files after
 the corresponding route. The Dancer scheme corresponding to the above
 PHP scheme might look something like this:
 
- views/top.tt
- views/mf/top.tt
- views/mf/subfeature/get.tt
- views/mf/subfeature/post.tt
- views/mf/subfeature/put.tt
- views/mf/subfeature/delete.tt
+    views/top.tt
+    views/mf/top.tt
+    views/mf/subfeature/get.tt
+    views/mf/subfeature/post.tt
+    views/mf/subfeature/put.tt
+    views/mf/subfeature/delete.tt
 
 This scheme maps Dancer routes 1:1 to template files, using a naming
 scheme that is easy to remember since it's nearly identical to the URL
@@ -92,22 +92,22 @@ If you have an HTML fragment page that is incorporated into your web app
 dynamically on the client side via Ajax, you will need a corresponding
 Dancer route for it, and probably a Perl module for it, too:
 
- views/parts/component.tt
- lib/App/Parts/Component.pm
+    views/parts/component.tt
+    lib/App/Parts/Component.pm
 
 Then in C<lib/App/Parts/Component.pm>:
 
- sub _get {
-     # ...work out how to build the component
- 
-     return template '/parts/component' => {
-         stuff => 'goes here'
-     };
- }
- 
- prefix '/parts' => sub {
-     get 'component' => \&_get;
- };
+    sub _get {
+        # ...work out how to build the component
+    
+        return template '/parts/component' => {
+            stuff => 'goes here'
+        };
+    }
+    
+    prefix '/parts' => sub {
+        get 'component' => \&_get;
+    };
 
 I chose the naming scheme for the function carefully. I want to be able
 to use short names here that correspond to the HTTP verb that the
@@ -130,21 +130,21 @@ page is served.
 For example, C<lib/App/MajorFeature.pm> might have something like this
 in it:
 
- sub Get {
-     # Work out how to build the main part of the top-level /mf page
-     ...Perl code here...
- 
-     # Assemble the pieces
-     return template '/mf/top' => {
-         component   => App::Parts::Component::Get(),
-         other_stuff => 'goes here',
-     };
- }
- 
- prefix '/mf' => sub {
-     get '/' => \&Get;
-     # other route handlers here
- };
+    sub Get {
+        # Work out how to build the main part of the top-level /mf page
+        ...Perl code here...
+    
+        # Assemble the pieces
+        return template '/mf/top' => {
+            component   => App::Parts::Component::Get(),
+            other_stuff => 'goes here',
+        };
+    }
+    
+    prefix '/mf' => sub {
+        get '/' => \&Get;
+        # other route handlers here
+    };
 
 Then within C<views/mf/top.tt>, you can reference C<$component> to
 bodily include that component's HTML fragment into the larger page.

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -1,0 +1,154 @@
+=head1 Medium-Scale Dancer, Part 3: Views
+
+The
+L<first|http://advent.perldancer.org/2015/3> two
+L<parts|http://advent.perldancer.org/2015/4> of this article series
+broke the monolithic C<lib/App.pm> file up into a series of Perl
+modules, each focused on a functional centroid of the application.
+
+If we describe the default C<lib/App.pm> file as monolithic, then we
+might get away with describing the view files as polylithic, because we
+do not need to break the view files up; they naturally map to web pages,
+so the app's URL scheme effectively keeps them separated by purpose.
+
+Although we will not start this part of the series needing to break up
+an overly large file, I can pass along some tips that might cause you to
+rethink the current structure of your app's C<views/*> tree.
+
+=head2 The View Naming Scheme Should Match the URL Scheme
+
+Older web frameworks like PHP, ASP, and JSP define the web app's URL
+structure in the file system. The route scheme defined in the previous
+part of this article series would look like this in PHP:
+
+ index.php
+ mf/index.php
+ mf/subfeature/index.php
+
+The view code — HTML and inline JavaScript — is intermixed with the
+server-side code in the same file. Worse, single files like
+C<mf/subfeature/index.php> have to handle multiple HTTP verbs; in our
+example, C<GET>, C<POST>, C<PUT>, and C<DELETE>. If each verb returns a
+different web page, you end up with a huge top-level C<if/elseif/else>
+block dividing the file up into a bunch of logically separate chunks.
+There are other bad consequences to this web framework design choice,
+such as that if you want your text editor to do syntax coloring
+correctly, it needs to be able to switch among PHP, JavaScript, and HTML
+syntax, all within the same file. The programmer ends up needing to do
+the same sort of context switching, too.
+
+Simply put, this is a mess.
+
+L<Template::Toolkit|http://www.template-toolkit.org/> — Dancer's default
+template system — solves part of this problem by separating the view
+files from the server-side Perl code. Modern web app development
+frameworks like L<Angular|https://angularjs.org/> solve the rest of it
+by encouraging you to move all of your JavaScript code into separate
+C<*.js> files, rather than put it inline in the HTML file.
+
+There is nothing about the way Dancer works that enforces or even
+encourages any particular C<views/*> file naming scheme. Thus this tip:
+for your own sanity, I recommend that you name your view files after the
+corresponding route. The Dancer scheme corresponding to the above PHP
+scheme might look something like this:
+
+ views/top.tt
+ views/mf/top.tt
+ views/mf/subfeature/get.tt
+ views/mf/subfeature/post.tt
+ views/mf/subfeature/put.tt
+ views/mf/subfeature/delete.tt
+
+This maps Dancer routes 1:1 to view files, using a naming scheme that is
+easy to remember, since it's nearly identical to the URL scheme. It's so
+simple a mapping that you could write a Perl one-liner to do the
+transform. By restricting yourself to a simple naming convention, you
+have removed a whole class of details that you have to keep in mind
+while working on your web app; you don't have to guess where the view
+file for a given route handler lives, you already I<know> where it
+lives. You will quickly rediscover this simple mapping years from now
+when you have to work on the web app again.
+
+This naming scheme is very much a suggestion, rather than a
+prescription. For one thing, you may find that the C<DELETE
+/mf/subfeature> route needs no view, because it just deletes one
+database record and then redirects you to C<GET /mf/subfeature> to show
+the change in the normal view. In that case, you would not need
+C<views/mf/subfeature/delete.tt>.
+
+The important thing is to I<have> a well-thought-out naming scheme, not
+necessarily to follow the one I've laid out above.
+
+=head2 Factor Common UI Elements Out
+
+If you reuse a particular UI element across different parts of your web
+app, put its view file into a special view directory. I use
+C<views/parts> for this.
+
+If you have an HTML fragment page that is incorporated into your web app
+dynamically on the client side via Ajax, you will need a corresponding
+Dancer route for it, and probably a Perl module for it, too:
+
+ views/parts/component.tt
+ lib/App/Parts/Component.pm
+
+Then in C<lib/App/Parts/Component.pm>:
+
+ sub _get {
+     # ...work out how to build the component
+ 
+     return template '/parts/component' => {
+         stuff => 'goes here'
+     };
+ }
+ 
+ prefix '/parts' => sub {
+     get 'component' => sub { _get(); };
+ };
+
+I chose the naming scheme for the function carefully. I want to be able
+to use short names here that correspond to the HTTP verb that the
+function handles without colliding with the short names exported by
+Dancer's DSL. The L<standard Perl style rules|http://perldoc.perl.org/perlstyle.html>
+say that a leading underscore marks a function that isn't meant to be
+called from outside the module, which is exactly correct here; only the
+route handler defined below that function should be calling it.
+
+You may prefer a different scheme, such as C<Get()>, even though this is
+unconventional Perl style. Again, the important thing is to I<have> a
+consistent style, not that you use the style I've chosen here.
+
+One argument in favor of C<Get()> over C<_get()> is that you might need
+to be able to reuse this route handler in another of your Perl modules,
+bodily incorporating the HTML fragment within another web page on the
+server side, thus saving an Ajax round trip the first time that that web
+page is served.
+
+For example, C<lib/App/MajorFeature.pm> might have something like this
+in it:
+
+ sub Get {
+     my ($ctx) = @_;     # see Part 2 for the definition of context()
+ 
+     # Work out how to build the main part of the top-level /mf page
+     ...Perl code here...
+ 
+     # Assemble the pieces
+     return template '/mf/top' => {
+         component   => App::Parts::Component::Get(),
+         other_stuff => 'goes here',
+     };
+ }
+ 
+ prefix '/mf' => sub {
+     get '/' => sub { Get(context); };
+     # other route handlers here <br />
+ };
+
+Then within C<views/mf/top.tt>, you can reference C<$component> to
+bodily include that component's HTML fragment into the larger page.
+
+Now that we have sorted out the purely server-side HTML and Perl code
+files, we will look at the Dancer app design decisions that affect its
+presentation to the browser in the
+L<next part of this article series|http://advent.perldancer.org/2015/6>.

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -128,8 +128,6 @@ For example, C<lib/App/MajorFeature.pm> might have something like this
 in it:
 
  sub Get {
-     my ($ctx) = @_;     # see Part 2 for the definition of context()
- 
      # Work out how to build the main part of the top-level /mf page
      ...Perl code here...
  
@@ -141,7 +139,7 @@ in it:
  }
  
  prefix '/mf' => sub {
-     get '/' => sub { Get(context); };
+     get '/' => sub { Get; };
      # other route handlers here <br />
  };
 

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -26,11 +26,11 @@ part of this article series would look like this in PHP:
 
     index.php
     mf/index.php
-    mf/subfeature/index.php
+    mf/sf/index.php
 
 The view code — HTML and inline JavaScript — is intermixed with the
 server-side code in the same file. Worse, single files like
-C<mf/subfeature/index.php> have to handle multiple HTTP verbs; in our
+C<mf/sf/index.php> have to handle multiple HTTP verbs; in our
 example, C<GET>, C<POST>, C<PUT>, and C<DELETE>. If each verb returns a
 different web page, you end up with a huge top-level C<if/elseif/else>
 block dividing the file up into a bunch of logically separate chunks.
@@ -57,10 +57,10 @@ PHP scheme might look something like this:
 
     views/top.tt
     views/mf/top.tt
-    views/mf/subfeature/get.tt
-    views/mf/subfeature/post.tt
-    views/mf/subfeature/put.tt
-    views/mf/subfeature/delete.tt
+    views/mf/sf/get.tt
+    views/mf/sf/post.tt
+    views/mf/sf/put.tt
+    views/mf/sf/delete.tt
 
 This scheme maps Dancer routes 1:1 to template files, using a naming
 scheme that is easy to remember since it's nearly identical to the URL
@@ -73,11 +73,10 @@ will quickly rediscover this simple mapping years from now when you have
 to work on the web app again.
 
 This naming scheme is very much a suggestion, rather than a
-prescription. For one thing, you may find that the C<DELETE
-/mf/subfeature> route needs no view, because it just deletes one
-database record and then redirects you to C<GET /mf/subfeature> to show
-the change in the normal view. In that case, you would not need
-C<views/mf/subfeature/delete.tt>.
+prescription. For one thing, you may find that the C<DELETE /mf/sf>
+route needs no view, because it just deletes one database record and
+then redirects you to C<GET /mf/sf> to show the change in the normal
+view. In that case, you would not need C<views/mf/sf/delete.tt>.
 
 The important thing is to I<have> a well-thought-out naming scheme, not
 necessarily to follow the one I've laid out above.

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -152,3 +152,8 @@ Now that we have sorted out the purely server-side HTML and Perl code
 files, we will look at the Dancer app design decisions that affect its
 presentation to the browser in the
 L<next part of this article series|http://advent.perldancer.org/2015/6>.
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
+++ b/danceradvent/public/articles/2015/5-medium-scale-part-3.pod
@@ -9,7 +9,7 @@ broke the monolithic C<lib/App.pm> file up into a series of Perl
 modules, each focused on a functional centroid of the application.
 
 If we describe the default C<lib/App.pm> file as monolithic, then we
-might get away with describing the view files as polylithic, because we
+might get away with describing the view files as polylithic because we
 do not need to break the view files up; they naturally map to web pages,
 so the app's URL scheme effectively keeps them separated by purpose.
 
@@ -61,15 +61,15 @@ scheme might look something like this:
  views/mf/subfeature/put.tt
  views/mf/subfeature/delete.tt
 
-This maps Dancer routes 1:1 to view files, using a naming scheme that is
-easy to remember, since it's nearly identical to the URL scheme. It's so
-simple a mapping that you could write a Perl one-liner to do the
-transform. By restricting yourself to a simple naming convention, you
-have removed a whole class of details that you have to keep in mind
-while working on your web app; you don't have to guess where the view
-file for a given route handler lives, you already I<know> where it
-lives. You will quickly rediscover this simple mapping years from now
-when you have to work on the web app again.
+This scheme maps Dancer routes 1:1 to view files, using a naming scheme
+that is easy to remember since it's nearly identical to the URL scheme.
+It's so simple a mapping that you could write a Perl one-liner to do the
+transform. Restricting yourself to a simple naming convention removes a
+whole class of details that you have to keep in mind while working on
+your web app; you don't have to guess where the view file for a given
+route handler lives, you already I<know> where it lives. You will
+quickly rediscover this simple mapping years from now when you have to
+work on the web app again.
 
 This naming scheme is very much a suggestion, rather than a
 prescription. For one thing, you may find that the C<DELETE

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -2,7 +2,7 @@
 
 =head1 Medium-Scale Dancer, Part 4: Front-End Matters
 
-This will be a short article, because the way you write your client-side
+This will be a short article because the way you write your client-side
 JavaScript code and serve it to your users has almost nothing to do with
 Dancer. Nevertheless, there are a few things we can say here that tie
 into the prior articles in
@@ -16,7 +16,7 @@ tens to hundreds of milliseconds — an important part of making a fast
 web site is to consolidate your JavaScript code into as few files as
 possible.
 
-Ideally, you'll end up with just one JavaScript file, perhaps called
+Ideally, you will end up with just one JavaScript file, perhaps called
 C<public/js/app.js>.
 
 This seems to go against the whole thrust of this article series so far,
@@ -32,10 +32,10 @@ front-end web server, your app will feel a lot snappier to your users,
 even though the size of the web app on disk is no smaller than before.
 
 You might not choose to compile all of your JavaScript down to a single
-file. If several files makes more sense for your purposes, I suggest
-that you name those files after the top-level URL that uses it. For
-example, the C</mf> URLs we've been using in examples so far should be
-served by a C<public/js/mf.js> file. You might still wish to develop
+file. If it makes more sense for your purposes to use several files, I
+suggest that you name those files after the top-level URL that uses it.
+For example, the C</mf> URLs we've been using in examples so far should
+be served by a C<public/js/mf.js> file. You might still wish to develop
 C<mf.js> in several different purpose-driven JS files, compiled down to
 C<mf.js> by RequireJS or a similar tool.
 
@@ -43,7 +43,7 @@ C<mf.js> by RequireJS or a similar tool.
 
 The
 L<Dancer2 Deployment Guide|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual/Deployment.pod>
-talks about running your app behind a front-end reverse proxy server,
+recommends running your app behind a front-end reverse proxy server
 such as nginx or Apache's C<mod_proxy>. I strongly encourage you to do
 this, even in development.
 
@@ -74,7 +74,7 @@ a vulnerability in the code. You don't want one of them to fill your
 disk up with log noise.
 
 Running a typical web app this way might reduce the number of hits that
-get down to the Dancer level by a factor of 10 to 100, since so much of
+get down to the Dancer level by a factor of 10 to 100 since so much of
 a modern web app is composed of static asset files: bitmaps, fonts, CSS
 files, JavaScript files, etc.
 

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 4: Front-End Matters
 
 This will be a short article, because the way you write your client-side

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -17,7 +17,7 @@ web site is to consolidate your JavaScript code into as few files as
 possible.
 
 Ideally, you will end up with just one JavaScript file, perhaps called
-C<public/js/app.js>.
+C<public/javascripts/app.js>.
 
 This seems to go against the whole thrust of this article series so far,
 which has been about factoring monolithic structures into smaller,
@@ -35,9 +35,9 @@ You might not choose to compile all of your JavaScript down to a single
 file. If it makes more sense for your purposes to use several files, I
 suggest that you name those files after the top-level URL that uses it.
 For example, the C</mf> URLs we've been using in examples so far should
-be served by a C<public/js/mf.js> file. You might still wish to develop
-C<mf.js> in several different purpose-driven JS files, compiled down to
-C<mf.js> by RequireJS or a similar tool.
+be served by a C<public/javascripts/mf.js> file. You might still wish to
+develop C<mf.js> in several different purpose-driven JS files, compiled
+down to C<mf.js> by RequireJS or a similar tool.
 
 =head2 Serve Static Assets Via a Front-End Reverse Proxy Server
 

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -1,0 +1,81 @@
+=head1 Medium-Scale Dancer, Part 4: Front-End Matters
+
+This will be a short article, because the way you write your client-side
+JavaScript code and serve it to your users has almost nothing to do with
+Dancer. Nevertheless, there are a few things we can say here that tie
+into the prior articles in
+L<this series|http://advent.perldancer.org/2015/3>.
+
+=head2 Consolidate JavaScript Files
+
+Because each HTTP round-trip over the Internet takes
+L<human-scale time|https://en.wikipedia.org/wiki/Mental_chronometry> —
+tens to hundreds of milliseconds — an important part of making a fast
+web site is to consolidate your JavaScript code into as few files as
+possible.
+
+Ideally, you'll end up with just one JavaScript file, perhaps called
+C<public/js/app.js>.
+
+This seems to go against the whole thrust of this article series so far,
+which has been about factoring monolithic structures into smaller,
+purpose-focused ones. But, there's a trick that lets you have your cake
+and eat it, too: tools like L<RequireJS|http://requirejs.org/> allow you
+to "compile" multiple JavaScript files down to a single file. Coupled
+with
+L<minification|https://en.wikipedia.org/wiki/Minification_(programming)>,
+L<compression|https://en.wikipedia.org/wiki/HTTP_compression>, and aggressive
+L<caching|https://en.wikipedia.org/wiki/Web_cache> rules in your
+front-end web server, your app will feel a lot snappier to your users,
+even though the size of the web app on disk is no smaller than before.
+
+You might not choose to compile all of your JavaScript down to a single
+file. If several files makes more sense for your purposes, I suggest
+that you name those files after the top-level URL that uses it. For
+example, the C</mf> URLs we've been using in examples so far should be
+served by a C<public/js/mf.js> file. You might still wish to develop
+C<mf.js> in several different purpose-driven JS files, compiled down to
+C<mf.js> by RequireJS or a similar tool.
+
+=head2 Serve Static Assets Via a Front-End Reverse Proxy Server
+
+The
+L<Dancer2 Deployment Guide|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual/Deployment.pod>
+talks about running your app behind a front-end reverse proxy server,
+such as nginx or Apache's C<mod_proxy>. I strongly encourage you to do
+this, even in development.
+
+The server setup given in the deployment guide will cause the front-end
+proxy server to handle all requests for static content files itself,
+passing URLs down to Dancer only when it cannot find a static asset with
+the requested name. This takes a huge load off of Dancer, which, you
+must remember, is dynamic Perl code, so it will naturally be slower than
+the highly optimized C code in the proxy server.
+
+You might want to temporarily add something like this to your Dancer app
+to make sure the front-end proxy is doing what it ought to:
+
+ hook before => sub {
+     my $path = request->path;
+     my $static = $path =~ m{\.html$|^/(bitmaps|css|fonts|js|svg)/};
+     warning "Static URL got past proxy server: $path\n" if $static;
+ };
+
+Adjust the C<$static> regex to match your site's URL scheme, then reload
+the web app, and work through all of the pages. In normal operation, you
+should never get this warning.
+
+Take this code out for production, though, because it can be triggered
+by visiting bogus URLs such as C</bitmaps/does-not-exist.png>. There are
+bots on the web that pound on web sites with random URLs, hoping to find
+a vulnerability in the code. You don't want one of them to fill your
+disk up with log noise.
+
+Running a typical web app this way might reduce the number of hits that
+get down to the Dancer level by a factor of 10 to 100, since so much of
+a modern web app is composed of static asset files: bitmaps, fonts, CSS
+files, JavaScript files, etc.
+
+In the L<next part of this article series|http://advent.perldancer.org/2015/7>,
+we will discover the REST API that was hidden inside this monolithic web
+app the whole time.

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -114,3 +114,8 @@ C<logrotate> in C<copytruncate> mode.
 In the L<next part of this article series|http://advent.perldancer.org/2015/7>,
 we will discover the REST API that was hidden inside this monolithic web
 app the whole time.
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -60,10 +60,11 @@ your C<config.yml> file:
 
     static_handler: 0
 
-Reload the web app, and work through all of the app's routes to make
-sure you don't get any new 404 errors; it may be helpful to have your
-browser's developer tools window up, displaying the Network log, while
-you do this, else you may not notice failed Ajax file loads.
+Reload the web app, then work through all of the app's routes to make
+sure you don't get any new 404 errors. It may be helpful to open the
+Network tab in your browser's developer tools alongside the browser
+window you're testing your web app in so that you're more likely to
+notice any new errors that happen in background Ajax calls.
 
 Running a typical web app this way might reduce the number of hits that
 get down to the Dancer level by a factor of 10 to 100 since so much of

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -54,29 +54,28 @@ the requested name. This takes a huge load off of Dancer, which, you
 must remember, is dynamic Perl code, so it will naturally be slower than
 the highly optimized C code in the proxy server.
 
-You might want to temporarily add something like this to your Dancer app
-to make sure the front-end proxy is doing what it ought to:
+To make sure the front-end proxy is doing what it ought to, you can
+disable Dancer's built-in handling of static resources by adding this to
+your C<config.yml> file:
 
-    hook before => sub {
-        my $path = request->path;
-        my $static = $path =~ m{\.html$|^/(bitmaps|css|fonts|js|svg)/};
-        warning "Static URL got past proxy server: $path\n" if $static;
-    };
+    static_handler: 0
 
-Adjust the C<$static> regex to match your site's URL scheme, then reload
-the web app, and work through all of the pages. In normal operation, you
-should never get this warning.
-
-Take this code out for production, though, because it can be triggered
-by visiting bogus URLs such as C</bitmaps/does-not-exist.png>. There are
-bots on the web that pound on web sites with random URLs, hoping to find
-a vulnerability in the code. You don't want one of them to fill your
-disk up with log noise.
+Reload the web app, and work through all of the app's routes to make
+sure you don't get any new 404 errors; it may be helpful to have your
+browser's developer tools window up, displaying the Network log, while
+you do this, else you may not notice failed Ajax file loads.
 
 Running a typical web app this way might reduce the number of hits that
 get down to the Dancer level by a factor of 10 to 100 since so much of
 a modern web app is composed of static asset files: bitmaps, fonts, CSS
 files, JavaScript files, etc.
+
+You might want to take this a step further, in fact. Instead of merely
+disabling Dancer's static file handler in your C<config.yml> file for
+the duration of a single test session, you could instead disable it
+permanently to your C<environments/development.yml> file, so that you
+find and fix such problems in development, before you deploy to
+production.
 
 In the L<next part of this article series|http://advent.perldancer.org/2015/7>,
 we will discover the REST API that was hidden inside this monolithic web

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -83,15 +83,32 @@ it useful to be able to put random files into my app's C<public/>
 directory on production systems so that I can have HTTP access to them
 via the Dancer app without restarting anything. Case in point: your
 Dancer app is running on a Linux server at a remote site, and you need
-to send a file too big to email to someone at that site, but they're
-running Windows on their PC, and the Linux box doesn't run Samba, so
-HTTP is the only easy way they have to get the file from your server
-onto their PC. (Can you tell that I'm writing from personal experience?
-Yes, indeed, I am.) Annnnyway, the point is, you don't want to be forced
-to adjust the front-end proxy settings in such a case to make it handle
-the I<ad hoc> file transfer. You want the Dancer app to backstop the
+to send a file too big to email to someone at that site, but that person
+runs Windows on their PC, and the Linux box doesn't run Samba, so HTTP
+is the only easy way they have to get the file from your server onto
+their PC. (Can you tell that I'm writing from personal experience?  Yes,
+indeed, I am.) Annnnyway, the point is, you don't want to be forced to
+adjust the front-end proxy settings in such a case to make it handle the
+I<ad hoc> file transfer. You want the Dancer app to backstop the
 front-end proxy in such cases, serving up any file the proxy server
 isn't preconfigured to serve.
+
+I can offer a related bit of advice here: if you must change the
+C<log_level> setting of a Dancer app running in a public-facing
+production setting, never raise it to C<core>, at least not for very
+long. Dancer logs all URLs retrieved at that level, and the default
+Dancer C<production.yml> file is configured to write log messages to a
+file file, rather than the console. On today's Internet, it is common to
+encounter bots that do nothing but request nonsense URLs from every web
+server they can find. These URLs may make sense to certain vulnerable
+applications, or they may simply be random, as the bot is searching for
+hidden resources on your server. You don't want a long series of such
+hits to fill your disk with log messages.
+
+Meta-advice: on production systems, configure your OS's log rotation
+system to keep your Dancer app's log file trimmed to a reasonable size.
+Dancer doesn't do that on its own. The Dancer2 docs recommend using
+C<logrotate> in C<copytruncate> mode.
 
 In the L<next part of this article series|http://advent.perldancer.org/2015/7>,
 we will discover the REST API that was hidden inside this monolithic web

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -57,11 +57,11 @@ the highly optimized C code in the proxy server.
 You might want to temporarily add something like this to your Dancer app
 to make sure the front-end proxy is doing what it ought to:
 
- hook before => sub {
-     my $path = request->path;
-     my $static = $path =~ m{\.html$|^/(bitmaps|css|fonts|js|svg)/};
-     warning "Static URL got past proxy server: $path\n" if $static;
- };
+    hook before => sub {
+        my $path = request->path;
+        my $static = $path =~ m{\.html$|^/(bitmaps|css|fonts|js|svg)/};
+        warning "Static URL got past proxy server: $path\n" if $static;
+    };
 
 Adjust the C<$static> regex to match your site's URL scheme, then reload
 the web app, and work through all of the pages. In normal operation, you

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -77,6 +77,22 @@ permanently to your C<environments/development.yml> file, so that you
 find and fix such problems in development, before you deploy to
 production.
 
+I cannot recommend doing this permanently at the C<config,yml> or
+C<environments/production.yml> levels, because I have occasionally found
+it useful to be able to put random files into my app's C<public/>
+directory on production systems so that I can have HTTP access to them
+via the Dancer app without restarting anything. Case in point: your
+Dancer app is running on a Linux server at a remote site, and you need
+to send a file too big to email to someone at that site, but they're
+running Windows on their PC, and the Linux box doesn't run Samba, so
+HTTP is the only easy way they have to get the file from your server
+onto their PC. (Can you tell that I'm writing from personal experience?
+Yes, indeed, I am.) Annnnyway, the point is, you don't want to be forced
+to adjust the front-end proxy settings in such a case to make it handle
+the I<ad hoc> file transfer. You want the Dancer app to backstop the
+front-end proxy in such cases, serving up any file the proxy server
+isn't preconfigured to serve.
+
 In the L<next part of this article series|http://advent.perldancer.org/2015/7>,
 we will discover the REST API that was hidden inside this monolithic web
 app the whole time.

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -74,8 +74,8 @@ files, JavaScript files, etc.
 You might want to take this a step further, in fact. Instead of merely
 disabling Dancer's static file handler in your C<config.yml> file for
 the duration of a single test session, you could instead disable it
-permanently to your C<environments/development.yml> file, so that you
-find and fix such problems in development, before you deploy to
+permanently in your C<environments/development.yml> file to ensure that
+you find and fix such problems in development, before you deploy to
 production.
 
 I cannot recommend doing this permanently at the C<config,yml> or

--- a/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
+++ b/danceradvent/public/articles/2015/6-medium-scale-part-4.pod
@@ -78,7 +78,7 @@ permanently in your C<environments/development.yml> file to ensure that
 you find and fix such problems in development, before you deploy to
 production.
 
-I cannot recommend doing this permanently at the C<config,yml> or
+I cannot recommend doing this permanently at the C<config.yml> or
 C<environments/production.yml> levels, because I have occasionally found
 it useful to be able to put random files into my app's C<public/>
 directory on production systems so that I can have HTTP access to them

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -21,22 +21,18 @@ reference (e.g. C<sub { ... }>) block. What do we get by moving those
 functions elsewhere, and what do we gain that makes it worth tolerating
 the ugly C<\&> syntax?
 
-We get two benefits by doing so.
+The first benefit we get from doing that is that named subroutines make
+stack traces easier to read.
 
-First, named subroutines make stack traces easier to read.
-
-Second, and far more important to our purposes here in this article
-series, it makes the URL structure of the web app explicit in the code.
-
-To some extent, you can see this by looking at your app's C<views>
-subdirectory, since a prior article in this series encouraged you to map
-template files 1:1 to Dancer routes, as much as possible. The problem
-with relying on the C<views> directory contents as a document for the
-web app's URL structure is that the OS's file system normally shows you
-only one layer of the directory hierarchy at a time. You have to go out
-of your way to see the whole tree in a compact form, on a single screen.
-That means you may never actually find yourself studying the hierarchy
-as a whole, and thus may never consider whether it is a cohesive design.
+Second — and far more important to our purposes here in this article
+series — defining your routes this way makes the URL structure of the
+web app explicit in the code. You are more likley to notice design
+problems by studying the indented route definitions in the Perl code
+than by looking at your app's C<views> subdirectory, even if it is
+structured exactly the same way as recommended in an earlier article in
+this series, simply because it is atypical to be looking at a full tree
+view of a filesystem. You end up with a kind of tunnel vision when
+looking at one directory at a time.
 
 This practice of defining Dancer route handlers as one-liners solves
 that. It ensures that every time you adjust the route handlers for your

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -4,12 +4,12 @@ In previous parts of L<this article series|/2015/3>, I defined each
 route handler as a one-liner, like so:
 
  prefix '/mf' => sub {
-     get '/' => sub { retrieve; };
+     get '/' => \&retrieve;
      prefix '/subfeature' => sub {
-         get  '/'    => sub { _get; };
-         post '/'    => sub { _post; };
-         put  '/'    => sub { _put; };
-         del  '/:id' => sub { _del; };
+         get  '/'    => \&_get;
+         post '/'    => \&_post;
+         put  '/'    => \&_put;
+         del  '/:id' => \&_del;
      };
  };
 
@@ -122,10 +122,10 @@ a bit:
 
  prefix '/api' => sub {
      prefix '/subfeature' => sub {
-         post '/'    => sub { _post; };
-         get  '/'    => sub { _get; };
-         put  '/:id' => sub { _put; };
-         del  '/:id' => sub { _del; };
+         post '/'    => \&_post;
+         get  '/'    => \&_get;
+         put  '/:id' => \&_put;
+         del  '/:id' => \&_del;
      };
  };
 
@@ -137,10 +137,10 @@ You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
  prefix '/api' => sub {
      prefix '/subfeature' => sub {
-         post '/'    => sub { _create; };
-         get  '/'    => sub { _read; };
-         put  '/:id' => sub { _update; };
-         del  '/:id' => sub { _delete; };
+         post '/'    => \&_create;
+         get  '/'    => \&_read;
+         put  '/:id' => \&_update;
+         del  '/:id' => \&_delete;
      };
  };
 

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -7,7 +7,7 @@ route handler as a one-liner, like so:
 
     prefix '/mf' => sub {
         get '' => \&retrieve;
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             get  ''     => \&_get;
             post ''     => \&_post;
             put  ''     => \&_put;
@@ -129,7 +129,7 @@ C<lib/App/API/SubFeature.pm>, and also refine the programming interface
 a bit:
 
     prefix '/api' => sub {
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             post ''     => \&_post;
             get  ''     => \&_get;
             put  '/:id' => \&_put;
@@ -144,7 +144,7 @@ scheme.
 You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
     prefix '/api' => sub {
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             post ''     => \&_create;
             get  ''     => \&_read;
             put  '/:id' => \&_update;
@@ -224,13 +224,13 @@ HTML-returning route, say something like this:
     use Dancer2 appname => 'App';
 
     sub _get {
-        return template '/mf/subfeature' => {
+        return template '/mf/sf' => {
             data => App::API::SubFeature::_get
         };
     }
 
     prefix '/mf' => sub {
-        prefix '/subfeature' => sub {
+        prefix '/sf' => sub {
             get '' => \&_get;
             # etc.
         }
@@ -257,7 +257,7 @@ this:
 That is, the API side is returning a complicated Perl data structure
 directly, intending that Dancer JSONify it for the caller, while a
 different route handler outside the JSON API section passes that same
-data structure into our C</mf/subfeature> template in order to provide
+data structure into our C</mf/sf> template in order to provide
 an alternative HTML rendering of the same data. The work to produce that
 complicated Perl data structure only has to happen in once place even
 though it is consumed as both HTML and JSON.

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -14,11 +14,12 @@ route handler as a one-liner, like so:
  };
 
 This is very much on purpose, despite the fact that Dancer lets you
-define all of the code for each route handler within the C<sub { ... }>
-block. Why add the extra function call layer?
+define all of the code for each route handler within an anonymous code
+reference (e.g. C<sub { ... }>) block. What do we get by moving those
+functions elsewhere, and what do we gain that makes it worth tolerating
+the ugly C<\&> syntax?
 
-Simple: I want to make the URL structure of my web app explicit in the
-code.
+Simple: it makes the URL structure of the web app explicit in the code.
 
 To some extent, you can see this by looking at your C<views> directory,
 since a prior article in this series encouraged you to map view files

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -191,6 +191,13 @@ automatically sets the the HTTP response's content type is set to
 C<application/json>. Parsing and using that reply on the client side in
 JavaScript is therefore trivial.
 
+This does not interfere with the more typical C<template> return value
+from route handlers, since those are labeled in such a way that they
+bypass the JSON serializer. This way of returning either JSON or HTML to
+the caller depending solely on whether the Dancer app uses C<template>
+feels natural and effortless to me, and therefore makes the code feel
+"right."
+
 If your new REST API route handlers previously returned HTML, and you
 have existing code that still needs this data in HTML form, I prefer to
 separate those Ajax call handlers into a different section of the URL

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -200,10 +200,10 @@ Doing so does mean that your existing HTML-returning route handlers have
 to be explicitly marked to return HTML instead:
 
     get '/some/html/returning/route' => sub {
-		send_as html => template '/some/template' => {
-			some => 'parameters',
-		};
-	};
+        send_as html => template '/some/template' => {
+            some => 'parameters',
+        };
+    };
 
 
 =head2 Returning the Same Data in Both HTML and JSON Forms
@@ -226,10 +226,10 @@ Consider this addition to the route handlers defined above:
     use Dancer2 appname => 'App';
 
     sub _get {
-		send_as html => template 'parts/mf/sf' => {
-			content => App::API::MajorFeature::SubFeature::_get(),
-		}
-	}
+        send_as html => template 'parts/mf/sf' => {
+            content => App::API::MajorFeature::SubFeature::_get(),
+        }
+    }
 
     prefix '/parts' => sub {
         prefix '/mf' => sub {
@@ -251,18 +251,18 @@ Then you can include one of those parts inside a complete HTML page:
     use Dancer2 appname => 'App';
 
     sub _get {
-		send_as html => template 'mf/sf' => {
-			some => 'parameters',
-			go   => 'here',
-			part => App::Parts::MajorFeature::SubFeature::_get(),
-		}
-	}
+        send_as html => template 'mf/sf' => {
+            some => 'parameters',
+            go   => 'here',
+            part => App::Parts::MajorFeature::SubFeature::_get(),
+        }
+    }
 
-	prefix '/mf' => sub {
-		prefix '/sf' => sub {
-			get '' => \&_get;
-		};
-	};
+    prefix '/mf' => sub {
+        prefix '/sf' => sub {
+            get '' => \&_get;
+        };
+    };
 
 Now we have three different ways to get the same data: as part of a
 complete web page (C<GET /mf/sf>), as an HTML fragment that we can

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -5,15 +5,15 @@
 In previous parts of L<this article series|/2015/3>, I defined each
 route handler as a one-liner, like so:
 
- prefix '/mf' => sub {
-     get '/' => \&retrieve;
-     prefix '/subfeature' => sub {
-         get  '/'    => \&_get;
-         post '/'    => \&_post;
-         put  '/'    => \&_put;
-         del  '/:id' => \&_del;
-     };
- };
+    prefix '/mf' => sub {
+        get '/' => \&retrieve;
+        prefix '/subfeature' => sub {
+            get  '/'    => \&_get;
+            post '/'    => \&_post;
+            put  '/'    => \&_put;
+            del  '/:id' => \&_del;
+        };
+    };
 
 This is very much on purpose, despite the fact that Dancer lets you
 define all of the code for each route handler within an anonymous code
@@ -77,12 +77,12 @@ storage.
 
 I prefer this mapping:
 
-   DB term    | HTTP verb
- +------------+----------
- | C = create | POST
- | R = read   | GET
- | U = update | PUT
- | D = delete | DELETE
+      DB term    | HTTP verb
+    +------------+----------
+    | C = create | POST
+    | R = read   | GET
+    | U = update | PUT
+    | D = delete | DELETE
 
 The R = C<GET> and D = C<DELETE> rules are obvious, but it may not be
 clear to you why the other two rules are correct.
@@ -123,14 +123,14 @@ Let's move the CRUD-like route handlers in C<lib/App/MajorFeature.pm> to
 C<lib/App/API/SubFeature.pm>, and also refine the programming interface
 a bit:
 
- prefix '/api' => sub {
-     prefix '/subfeature' => sub {
-         post '/'    => \&_post;
-         get  '/'    => \&_get;
-         put  '/:id' => \&_put;
-         del  '/:id' => \&_del;
-     };
- };
+    prefix '/api' => sub {
+        prefix '/subfeature' => sub {
+            post '/'    => \&_post;
+            get  '/'    => \&_get;
+            put  '/:id' => \&_put;
+            del  '/:id' => \&_del;
+        };
+    };
 
 My choice to use leading underscores in these module-internal route
 handler function names lets us parallel the Dancer DSL keyword naming
@@ -138,14 +138,14 @@ scheme.
 
 You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
- prefix '/api' => sub {
-     prefix '/subfeature' => sub {
-         post '/'    => \&_create;
-         get  '/'    => \&_read;
-         put  '/:id' => \&_update;
-         del  '/:id' => \&_delete;
-     };
- };
+    prefix '/api' => sub {
+        prefix '/subfeature' => sub {
+            post '/'    => \&_create;
+            get  '/'    => \&_read;
+            put  '/:id' => \&_update;
+            del  '/:id' => \&_delete;
+        };
+    };
 
 As in the previous article in this series, the leading underscore
 convention saves us some aggravation here since C<delete> is a Perl
@@ -157,23 +157,23 @@ JavaScript code that made the Ajax call to one of these APIs. One of the
 best features of Dancer is that automatic JSON encoding is built right
 in. We might define the C<_create()> function referenced above as:
 
- sub _create {
-     my $params = request->params;
-     my $db     = get_db_conn;
- 
-     if ($db->create_something($params->{arg1}, $params->{arg2})) {
-         return {
-             success => JSON::true,
-             id      => $db->last_insert_id(),
-         };
-     }
-     else {
-         return {
-             success => JSON::false,
-             error   => 'failed to create record: ' . $db->last_error(),
-         };
-     }
- }
+    sub _create {
+        my $params = request->params;
+        my $db     = get_db_conn;
+    
+        if ($db->create_something($params->{arg1}, $params->{arg2})) {
+            return {
+                success => JSON::true,
+                id      => $db->last_insert_id(),
+            };
+        }
+        else {
+            return {
+                success => JSON::false,
+                error   => 'failed to create record: ' . $db->last_error(),
+            };
+        }
+    }
 
 In Dancer, a hash reference returned from a route handler is
 automatically JSON-encoded, and the HTTP response's content type is set
@@ -197,11 +197,11 @@ simply calls into its own API and provides an alternate rendering of the
 same data. Given that Dancer templates easily consume hashrefs, the
 HTML-side route handler might be nearly trivial:
 
- sub get_subfeature_html {
-     return template '/mf/subfeature' => {
-         data => App::API::SubFeature::_read
-     };
- }
+    sub get_subfeature_html {
+        return template '/mf/subfeature' => {
+            data => App::API::SubFeature::_read
+        };
+    }
 
 This article series concludes with a scheme for
 L<hot code reloading|/2015/8>, a very useful feature in any Dancer

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -23,15 +23,15 @@ the ugly C<\&> syntax?
 
 Simple: it makes the URL structure of the web app explicit in the code.
 
-To some extent, you can see this by looking at your C<views> directory,
-since a prior article in this series encouraged you to map view files
-1:1 to Dancer routes, as much as possible. The problem with relying on
-the C<views> directory contents as a document for the web app's URL
-structure is that the OS's file system normally shows you only one layer
-of the directory hierarchy at a time. You have to go out of your way to
-see the whole tree in a compact form, on a single screen. That means you
-may never actually find yourself studying the hierarchy as a whole, and
-thus may never consider whether it is a cohesive design.
+To some extent, you can see this by looking at your app's C<views>
+subdirectory, since a prior article in this series encouraged you to map
+template files 1:1 to Dancer routes, as much as possible. The problem
+with relying on the C<views> directory contents as a document for the
+web app's URL structure is that the OS's file system normally shows you
+only one layer of the directory hierarchy at a time. You have to go out
+of your way to see the whole tree in a compact form, on a single screen.
+That means you may never actually find yourself studying the hierarchy
+as a whole, and thus may never consider whether it is a cohesive design.
 
 This practice of defining Dancer route handlers as one-liners solves
 that. It ensures that every time you adjust the route handlers for your

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -165,7 +165,7 @@ in.
 
 First, enable the feature by adding this to your C<config.yml> file:
 
-    serializer: JSON
+    serializer: "JSON"
 
 That lets us write the C<_create()> function referenced above as:
 
@@ -187,94 +187,100 @@ That lets us write the C<_create()> function referenced above as:
         }
     }
 
-By telling Dancer that we want unlabeled return values from route
-handlers to be sent through the built-in JSON serializer, it not only
-converts Perl data structures to their JSON equivalents, it also
-automatically sets the response's HTTP C<Content-Type> header to
+By telling Dancer that we want all routes to return JSON unless
+explicitly told otherwise, we can simply return Perl data structures and
+have Dancer translate them into JSON form for us. It will also
+automatically set the response's HTTP C<Content-Type> header to
 C<application/json>. Parsing and using that reply on the client side in
-JavaScript is therefore trivial.
+JavaScript is therefore trivial. Many web frameworks can consume such
+APIs directly, such as jQuery via
+L<C<$.getJSON()>|https://api.jquery.com/jQuery.getJSON/>.
 
-This does not interfere with the more typical C<template> return value
-from route handlers, since those are labeled in such a way that they
-bypass the JSON serializer. This way of returning either JSON or HTML to
-the caller depending solely on whether the Dancer app uses C<template>
-feels natural and effortless to me, and therefore makes the code feel
-"right."
+Doing so does mean that your existing HTML-returning route handlers have
+to be explicitly marked to return HTML instead:
 
-Dancer does have a way to force use of a particular serializer: the
-L<C<send_as> DSL keyword|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod#send_as>.
-My immediate reaction to finding a C<send_as> call in a Dancer app is to
-L<wrinlke my nose|https://en.wikipedia.org/wiki/Code_smell> for the same
-reason I mistrust type casts elsewhere in code. Both mechanisms force a
-value from its natural data type to another one; a conscientious
-developer asks whether there is a good reason to fight the default
-conversion rules in each case.
+    get '/some/html/returning/route' => sub {
+		send_as html => template '/some/template' => {
+			some => 'parameters',
+		};
+	};
 
 
 =head2 Returning the Same Data in Both HTML and JSON Forms
 
-If your new REST API route handlers previously returned HTML, and you
-have existing code that still needs this data in HTML form, I prefer to
-separate those Ajax call handlers into a different section of the URL
-hierarchy: C</parts>. The rule is simple: C</api> routes return JSON,
-whereas C</parts> routes return HTML fragments. Those fragments are
-intended to be inserted into an existing DOM via JavaScript. The
-C</parts> section of the URL hierarchy separates out such route handlers
-from those that return whole HTML pages.
+You might now be asking why you would arrange things as above, where the
+default serializer is JSON and HTML-returning routes have to be
+explicitly marked. If your application returns HTML more often than
+JSON, this may seem backwards. Wouldn't it be simpler to leave the
+default serializer unset, so that C<template> calls and such return
+normally, and mark the JSON-returning API route handlers explicitly
+instead?
 
-Sometimes you need the same data in both HTML and JSON forms. I find
-that Dancer makes this easy. In the Perl module defining the
-HTML-returning route, say something like this:
+You could indeed do that, but then you lose a nice side benefit of this
+arrangement: it makes it easy to define parallel route handlers for
+returning HTML-rendered versions of APIs that return raw JSON data.
 
-    package App::SubFeature
+Consider this addition to the route handlers defined above:
+
+    package App::Parts::MajorFeature::SubFeature
     use Dancer2 appname => 'App';
 
     sub _get {
-        return template '/mf/sf' => {
-            data => App::API::SubFeature::_get
+		send_as html => template 'parts/mf/sf' => {
+			content => App::API::MajorFeature::SubFeature::_get(),
+		}
+	}
+
+    prefix '/parts' => sub {
+        prefix '/mf' => sub {
+            prefix '/sf' => sub {
+                get '' => \&_get;
+            };
         };
-    }
+    };
 
-    prefix '/mf' => sub {
-        prefix '/sf' => sub {
-            get '' => \&_get;
-            # etc.
-        }
-    }
+Briefly, what this does is define a C</parts> route hierarchy that is
+parallel to the C</api> hierarchy, with the former implemented in terms
+of the latter. That is, the application's API returns JSON, and the
+applications "parts" subsystem returns HTML fragments that present the
+same data the JSON APIs return but in HTML form.
 
-The key line is in the middle of the example, which calls over into the
-module defining the corresponding API route handler, which looks like
-this:
+Then you can include one of those parts inside a complete HTML page:
 
-    package App::API::SubFeature
+    package App::MajorFeature::SubFeature
     use Dancer2 appname => 'App';
 
     sub _get {
-        return {
-            some => 'complicated',
-            data => 'structure',
-        };
-    }
+		send_as html => template 'mf/sf' => {
+			some => 'parameters',
+			go   => 'here',
+			part => App::Parts::MajorFeature::SubFeature::_get(),
+		}
+	}
 
-    prefix '/api' => sub {
-        # more route defs, including one to call _get() above
-    }
+	prefix '/mf' => sub {
+		prefix '/sf' => sub {
+			get '' => \&_get;
+		};
+	};
 
-That is, the API side is returning a complicated Perl data structure
-directly, intending that Dancer JSONify it for the caller, while a
-different route handler outside the JSON API section passes that same
-data structure into our C</mf/sf> template in order to provide
-an alternative HTML rendering of the same data. The work to produce that
-complicated Perl data structure only has to happen in once place even
-though it is consumed as both HTML and JSON.
+Now we have three different ways to get the same data: as part of a
+complete web page (C<GET /mf/sf>), as an HTML fragment that we can
+insert into an existing web page via Ajax on the browser side or textual
+inclusion on the Dancer side (C<GET /parts/mf/sf>), and as raw JSON data
+that we could process on the browser side (C<GET /api/mf/sf>).
 
-This pattern is common in code that needs to return an initial view of a
-given data structure which is later updated via Ajax: on some
-change-triggering event, the Ajax handler sends new data back to the
-Dancer app and gets back an updated JSON data structure, with which it
-updates the initial HTML returned by the Dancer app.
+This layered design pattern is common in code that needs to return an
+initial view of a given data structure which is later updated via Ajax.
+The initial page load pre-renders the raw data on the Dancer side by
+calling down into its own C<App::Parts> route handler, textually
+including the returned HTML fragment into the larger HTML page. Then as
+dynamic events happen on the browser side, the JavaScript code handling
+those events can either fetch a new rendering of the data by calling
+back to the C</parts> route handler that serves up that HTML fragment,
+or it can get the same data in JSON form via an C</api> call.
 
-This has two additional benefits besides avoiding a violation of the
+This design has two additional benefits besides avoiding a violation of the
 L<DRY principle|https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>:
 
 First, it saves one HTTP round trip on the initial request over the

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -126,11 +126,13 @@ C<lib/App/API/MajorFeature/SubFeature.pm>. We can also refine the
 programming interface a bit:
 
     prefix '/api' => sub {
-        prefix '/sf' => sub {
-            post ''     => \&_post;
-            get  ''     => \&_get;
-            put  '/:id' => \&_put;
-            del  '/:id' => \&_del;
+        prefix '/mf' => sub {
+            prefix '/sf' => sub {
+                post ''     => \&_post;
+                get  ''     => \&_get;
+                put  '/:id' => \&_put;
+                del  '/:id' => \&_del;
+            };
         };
     };
 
@@ -141,11 +143,13 @@ scheme.
 You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
     prefix '/api' => sub {
-        prefix '/sf' => sub {
-            post ''     => \&_create;
-            get  ''     => \&_read;
-            put  '/:id' => \&_update;
-            del  '/:id' => \&_delete;
+        prefix '/mf' => sub {
+            prefix '/sf' => sub {
+                post ''     => \&_create;
+                get  ''     => \&_read;
+                put  '/:id' => \&_update;
+                del  '/:id' => \&_delete;
+            };
         };
     };
 

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -210,6 +210,9 @@ value from its natural data type to another one; a conscientious
 developer asks whether there is a good reason to fight the default
 conversion rules in each case.
 
+
+=head2 Returning the Same Data in Both HTML and JSON Forms
+
 If your new REST API route handlers previously returned HTML, and you
 have existing code that still needs this data in HTML form, I prefer to
 separate those Ajax call handlers into a different section of the URL

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -302,3 +302,8 @@ code.
 This article series concludes with a scheme for
 L<hot code reloading|/2015/8>, a very useful feature in any Dancer
 app, but especially helpful as your app grows larger.
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -26,7 +26,7 @@ stack traces easier to read.
 
 Second — and far more important to our purposes here in this article
 series — defining your routes this way makes the URL structure of the
-web app explicit in the code. You are more likley to notice design
+web app explicit in the code. You are more likely to notice design
 problems by studying the indented route definitions in the Perl code
 than by looking at your app's C<views> subdirectory, even if it is
 structured exactly the same way as recommended in an earlier article in

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -120,9 +120,10 @@ That's enough design philosophy; how does all that affect our Dancer
 code? We might decide that since we've almost got a REST API here that
 we might want to push it the rest of the way.
 
-Let's move the CRUD-like route handlers in C<lib/App/MajorFeature.pm> to
-C<lib/App/API/SubFeature.pm>, and also refine the programming interface
-a bit:
+Let's move the CRUD-like route handlers in
+C<lib/App/MajorFeature/SubFeature.pm> to
+C<lib/App/API/MajorFeature/SubFeature.pm>. We can also refine the
+programming interface a bit:
 
     prefix '/api' => sub {
         prefix '/sf' => sub {

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -198,6 +198,15 @@ the caller depending solely on whether the Dancer app uses C<template>
 feels natural and effortless to me, and therefore makes the code feel
 "right."
 
+Dancer does have a way to force use of a particular serializer: the
+L<C<send_as> DSL keyword|https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Manual.pod#send_as>.
+My immediate reaction to finding a C<send_as> call in a Dancer app is to
+L<wrinlke my nose|https://en.wikipedia.org/wiki/Code_smell> for the same
+reason I mistrust type casts elsewhere in code. Both mechanisms force a
+value from its natural data type to another one; a conscientious
+developer asks whether there is a good reason to fight the default
+conversion rules in each case.
+
 If your new REST API route handlers previously returned HTML, and you
 have existing code that still needs this data in HTML form, I prefer to
 separate those Ajax call handlers into a different section of the URL

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -4,12 +4,12 @@ In previous parts of L<this article series|/2015/3>, I defined each
 route handler as a one-liner, like so:
 
  prefix '/mf' => sub {
-     get '/' => sub { retrieve(context); };
+     get '/' => sub { retrieve; };
      prefix '/subfeature' => sub {
-         get  '/'    => sub { _get(context); };
-         post '/'    => sub { _post(context); };
-         put  '/'    => sub { _put(context); };
-         del  '/:id' => sub { _del(context); };
+         get  '/'    => sub { _get; };
+         post '/'    => sub { _post; };
+         put  '/'    => sub { _put; };
+         del  '/:id' => sub { _del; };
      };
  };
 
@@ -122,10 +122,10 @@ a bit:
 
  prefix '/api' => sub {
      prefix '/subfeature' => sub {
-         post '/'    => sub { _post(context); };
-         get  '/'    => sub { _get(context); };
-         put  '/:id' => sub { _put(context); };
-         del  '/:id' => sub { _del(context); };
+         post '/'    => sub { _post; };
+         get  '/'    => sub { _get; };
+         put  '/:id' => sub { _put; };
+         del  '/:id' => sub { _del; };
      };
  };
 
@@ -137,10 +137,10 @@ You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
  prefix '/api' => sub {
      prefix '/subfeature' => sub {
-         post '/'    => sub { _create(context); };
-         get  '/'    => sub { _read(context); };
-         put  '/:id' => sub { _update(context); };
-         del  '/:id' => sub { _delete(context); };
+         post '/'    => sub { _create; };
+         get  '/'    => sub { _read; };
+         put  '/:id' => sub { _update; };
+         del  '/:id' => sub { _delete; };
      };
  };
 
@@ -155,10 +155,8 @@ best features of Dancer is that automatic JSON encoding is built right
 in. We might define the C<_create()> function referenced above as:
 
  sub _create {
-     my ($ctx) = @_;     # see Part 2 for the definition of context()
- 
-     my $params = $ctx->{request}->params;
-     my $db     = $ctx->{dbconn};
+     my $params = request->params;
+     my $db     = get_db_conn;
  
      if ($db->create_something($params->{arg1}, $params->{arg2})) {
          return {
@@ -198,7 +196,7 @@ HTML-side route handler might be nearly trivial:
 
  sub get_subfeature_html {
      return template '/mf/subfeature' => {
-         data => App::API::SubFeature::_read(@_[0]),  # pass along $ctx
+         data => App::API::SubFeature::_read
      };
  }
 

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 5: REST APIs and JSON
 
 In previous parts of L<this article series|/2015/3>, I defined each

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -160,7 +160,11 @@ The only other thing to change here is that REST APIs normally return
 JSON or XML. I prefer JSON since that's directly usable by the
 JavaScript code that made the Ajax call to one of these APIs. One of the
 best features of Dancer is that automatic JSON encoding is built right
-in. We might define the C<_create()> function referenced above as:
+in. First, enable the feature by adding this to your C<config.yml> file:
+
+    serializer: JSON
+
+That lets us write the C<_create()> function referenced above as:
 
     sub _create {
         my $params = request->params;
@@ -180,10 +184,12 @@ in. We might define the C<_create()> function referenced above as:
         }
     }
 
-In Dancer, a hash reference returned from a route handler is
-automatically JSON-encoded, and the HTTP response's content type is set
-to C<application/json>. Parsing and using that reply on the client side
-in JavaScript is therefore trivial.
+By telling Dancer that we want unlabeled return values from route
+handlers to be sent through the built-in JSON serializer, it not only
+converts Perl data structures to their JSON equivalents, it also
+automatically sets the the HTTP response's content type is set to
+C<application/json>. Parsing and using that reply on the client side in
+JavaScript is therefore trivial.
 
 If your new REST API route handlers previously returned HTML, and you
 have existing code that still needs this data in HTML form, I prefer to

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -21,7 +21,12 @@ reference (e.g. C<sub { ... }>) block. What do we get by moving those
 functions elsewhere, and what do we gain that makes it worth tolerating
 the ugly C<\&> syntax?
 
-Simple: it makes the URL structure of the web app explicit in the code.
+We get two benefits by doing so.
+
+First, named subroutines make stack traces easier to read.
+
+Second, and far more important to our purposes here in this article
+series, it makes the URL structure of the web app explicit in the code.
 
 To some extent, you can see this by looking at your app's C<views>
 subdirectory, since a prior article in this series encouraged you to map

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -214,7 +214,7 @@ explicitly marked. If your application returns HTML more often than
 JSON, this may seem backwards. Wouldn't it be simpler to leave the
 default serializer unset, so that C<template> calls and such return
 normally, and mark the JSON-returning API route handlers explicitly
-instead?
+instead via C<send_as JSON =E<gt>...>?
 
 You could indeed do that, but then you lose a nice side benefit of this
 arrangement: it makes it easy to define parallel route handlers for

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -216,19 +216,57 @@ intended to be inserted into an existing DOM via JavaScript. The
 C</parts> section of the URL hierarchy separates out such route handlers
 from those that return whole HTML pages.
 
-If you need both JSON and HTML versions of this data, you can use this
-function for both cases: directly as a route handler, letting Dancer
-translate the hashref to JSON for you, and indirectly from another route
-handler, consuming the hashref and translating it to HTML form. The app
-simply calls into its own API and provides an alternate rendering of the
-same data. Given that Dancer templates easily consume hashrefs, the
-HTML-side route handler might be nearly trivial:
+Sometimes you need the same data in both HTML and JSON forms. I find
+that Dancer makes this easy. In the Perl module defining the
+HTML-returning route, say something like this:
 
-    sub get_subfeature_html {
+    package App::SubFeature
+    use Dancer2 appname => 'App';
+
+    sub _get {
         return template '/mf/subfeature' => {
-            data => App::API::SubFeature::_read
+            data => App::API::SubFeature::_get
         };
     }
+
+    prefix '/mf' => sub {
+        prefix '/subfeature' => sub {
+            get '' => \&_get;
+            # etc.
+        }
+    }
+
+The key line is in the middle of the example, which calls over into the
+module defining the corresponding API route handler, which looks like
+this:
+
+    package App::API::SubFeature
+    use Dancer2 appname => 'App';
+
+    sub _get {
+        return {
+            some => 'complicated',
+            data => 'structure',
+        };
+    }
+
+    prefix '/api' => sub {
+        # more route defs, including one to call _get() above
+    }
+
+That is, the API side is returning a complicated Perl data structure
+directly, intending that Dancer JSONify it for the caller, while a
+different route handler outside the JSON API section passes that same
+data structure into our C</mf/subfeature> template in order to provide
+an alternative HTML rendering of the same data. The work to produce that
+complicated Perl data structure only has to happen in once place even
+though it is consumed as both HTML and JSON.
+
+This pattern is common in code that needs to return an initial view of a
+given data structure which is later updated via Ajax: on some
+change-triggering event, the Ajax handler sends new data back to the
+Dancer app and gets back an updated JSON data structure, with which it
+updates the initial HTML returned by the Dancer app.
 
 This article series concludes with a scheme for
 L<hot code reloading|/2015/8>, a very useful feature in any Dancer

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -268,6 +268,24 @@ change-triggering event, the Ajax handler sends new data back to the
 Dancer app and gets back an updated JSON data structure, with which it
 updates the initial HTML returned by the Dancer app.
 
+This has two additional benefits besides avoiding a violation of the
+L<DRY principle|https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>:
+
+First, it saves one HTTP round trip on the initial request over the
+common alternative design, where the server simply returns an empty HTML
+container which must be filled by JavaScript code with a subsequent
+JavaScript Ajax call; HTTP round-trips are usually expensive enough to
+add human-scale amounts of delay to your web app's response time, so any
+time you spend to remove unnecessary round-trips usually pays immediate
+tangible benefits.
+
+Second, this design ensures that your web app returns an initial HTML
+view of the data even to clients not running JavaScript. Even if you can
+ensure that your normal web users will run JavaScript, you may gain some
+SEO benefit by returning an HTML form of your web app's dynamic content
+to web spiders that refuse to run embedded and referenced JavaScript
+code.
+
 This article series concludes with a scheme for
 L<hot code reloading|/2015/8>, a very useful feature in any Dancer
 app, but especially helpful as your app grows larger.

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -1,0 +1,207 @@
+=head1 Medium-Scale Dancer, Part 5: REST APIs and JSON
+
+In previous parts of L<this article series|/2015/3>, I defined each
+route handler as a one-liner, like so:
+
+ prefix '/mf' => sub {
+     get '/' => sub { retrieve(context); };
+     prefix '/subfeature' => sub {
+         get  '/'    => sub { _get(context); };
+         post '/'    => sub { _post(context); };
+         put  '/'    => sub { _put(context); };
+         del  '/:id' => sub { _del(context); };
+     };
+ };
+
+This is very much on purpose, despite the fact that Dancer lets you
+define all of the code for each route handler within the C<sub { ... }>
+block. Why add the extra function call layer?
+
+Simple: I want to make the URL structure of my web app explicit in the
+code.
+
+To some extent, you can see this by looking at your C<views> directory,
+since a prior article in this series encouraged you to map view files
+1:1 to Dancer routes, as much as possible. The problem with relying on
+the C<views> directory contents as a document for the web app's URL
+structure is that the OS's file system normally shows you only one layer
+of the directory hierarchy at a time. You have to go out of your way to
+see the whole tree in a compact form, on a single screen. That means you
+may never actually find yourself studying the hierarchy as a whole, and
+thus may never consider whether it is a cohesive design.
+
+This practice of defining Dancer route handlers as one-liners solves
+that. It ensures that every time you adjust the route handlers for your
+site, you're doing so while looking at the neighboring routes; you will
+be defining new routes in context, not independently. This counteracts
+the entropic forces that result in API design drift, because it
+implicitly encourages you to define new routes that fit logically into
+the scheme you defined previously. Without this extra Perl function call
+layer, the route definitions are visually broken up, so that you cannot
+see the whole design on a single screen. The resulting URL scheme can
+turn into a mess, as developers hack on the app over the course of
+years.
+
+This is also why I have carefully lined up the blocks and
+L<fat commas|https://en.wikipedia.org/wiki/Fat_comma> in the route
+definitions: I want patterns in the URL scheme to jump out at me.
+Left-justifying everything obscures these patterns.
+
+Now you may be asking, why does all this matter?
+
+The reason is simple: When you make patterns in the URL scheme
+graphically apparent, you may discover some previously hidden practical
+value that was just sitting there waiting to be exploited. It works for
+the same reason that seeing a plot for a numeric data set for the first
+time sometimes creates a clear call to action.
+
+It turns out that the example route scheme we've been defining
+throughout this article series includes a web API; it's just been
+sitting there, waiting to be discovered. With a bit of polishing, it
+might even turn into a proper
+L<REST|https://en.wikipedia.org/wiki/Representational_state_transfer>
+API. Let's try.
+
+Look back up at that route definition block above. What does it remind
+you of? If you said
+L<CRUD|https://en.wikipedia.org/wiki/Create,_read,_update_and_delete>,
+go to the head of the class.
+
+Now, HTTP verbs do not correspond directly to CRUD, because HTTP was not
+designed to be a CRUD API. There are competing design philosophies when
+it comes to mapping HTTP verbs to the CRUD model of persistent data
+storage.
+
+I prefer this mapping:
+
+   DB term    | HTTP verb
+ +------------+----------
+ | C = create | POST
+ | R = read   | GET
+ | U = udpate | PUT
+ | D = delete | DELETE
+
+The R = C<GET> and D = C<DELETE> rules are obvious, but it may not be
+clear to you why the other two rules are correct.
+
+L<The HTTP spec|http://www.w3.org/Protocols/rfc2616/rfc2616.html>
+defines C<POST> and C<PUT> so that they're nearly interchangeable, which
+is how we ended up with competing REST/CRUD API design philosophies.
+
+Some web API designers like to use C<POST> for both create and update
+operations, since you can distinguish the cases based on whether the
+HTTP request contains a database row ID: if so, it's a request to update
+an existing record, else it's a record creation request.
+
+That justification is fine in a web framework that defines the URL
+scheme in the file system, such as PHP, ASP, or JSP, since it is normal
+to handle all four verbs in a single file in that sort of web framework.
+In Dancer, my preferred scheme works better, since it defines one route
+per CRUD operation.
+
+Although the HTTP spec defines C<PUT> and C<POST> as partially
+interchangeable, you must not swap the C<PUT> and C<POST> verbs from the
+way I've defined them above. The HTTP spec says
+L<C<PUT> is idempotent|http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1>, meaning
+that the browser is allowed to cache C<PUT> requests, suppressing
+subsequent identical calls if the request parameters do not change. In
+CRUD terms, this means that if you define "create" in terms of C<PUT>,
+the browser mignt not let you create two records with identical
+contents but different IDs, which means you risk losing data. The HTTP
+spec does not allow browsers to assume that identical C<POST> calls are
+idempotent, however, so we use that verb for CRUD's create operation,
+leaving C<PUT> = update.
+
+That's enough design philosophy; how does all that affect our Dancer
+code? We might decide that since we've almost got a REST API here that
+we might want to push it the rest of the way.
+
+Let's move the CRUD-like route handlers in C<lib/App/MajorFeature.pm> to
+C<lib/App/API/SubFeature.pm>, and also refine the programming interface
+a bit:
+
+ prefix '/api' => sub {
+     prefix '/subfeature' => sub {
+         post '/'    => sub { _post(context); };
+         get  '/'    => sub { _get(context); };
+         put  '/:id' => sub { _put(context); };
+         del  '/:id' => sub { _del(context); };
+     };
+ };
+
+My choice to use leading underscores in these module-internal route
+handler function names lets us parallel the Dancer DSL keyword naming
+scheme.
+
+You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
+
+ prefix '/api' => sub {
+     prefix '/subfeature' => sub {
+         post '/'    => sub { _create(context); };
+         get  '/'    => sub { _read(context); };
+         put  '/:id' => sub { _update(context); };
+         del  '/:id' => sub { _delete(context); };
+     };
+ };
+
+As in the previous article in this series, the leading underscore
+convention saves us some aggravation here, since C<delete> is a Perl
+keyword, and C<read> is a core Perl function.
+
+The only other thing to change here is that REST APIs normally return
+JSON or XML. I prefer JSON, since that's directly usable by the
+JavaScript code that made the Ajax call to one of these APIs. One of the
+best features of Dancer is that automatic JSON encoding is built right
+in. We might define the C<_create()> function referenced above as:
+
+ sub _create {
+     my ($ctx) = @_;     # see Part 2 for the definition of context()
+ 
+     my $params = $ctx->{request}->params;
+     my $db     = $ctx->{dbconn};
+ 
+     if ($db->create_something($params->{arg1}, $params->{arg2})) {
+         return {
+             success => JSON::true,
+             id      => $db->last_insert_id(),
+         };
+     }
+     else {
+         return {
+             success => JSON::false,
+             error   => 'failed to create record: ' . $db->last_error(),
+         };
+     }
+ }
+
+In Dancer, a hash reference returned from a route handler is
+automatically JSON-encoded, and the HTTP response's content type is set
+to C<application/json>. Parsing and using that reply on the client side
+in JavaScript is therefore trivial.
+
+If your new REST API route handlers previously returned HTML, and you
+have existing code that still needs this data in HTML form, I prefer to
+separate those Ajax call handlers into a different section of the URL
+hierarchy: C</parts>. The rule is simple: C</api> routes return JSON,
+whereas C</parts> routes return HTML fragments. Those fragments are
+intended to be inserted into an existing DOM via JavaScript. The
+C</parts> section of the URL hierarchy separates out such route handlers
+from those that return whole HTML pages.
+
+If you need both JSON and HTML versions of this data, you can use this
+function for both cases: directly as a route handler, letting Dancer
+translate the hashref to JSON for you, and indirectly from another route
+handler, consuming the hashref and translating it to HTML form. The app
+simply calls into its own API and provides an alternate rendering of the
+same data. Given that Dancer templates easily consume hashrefs, the
+HTML-side route handler might be nearly trivial:
+
+ sub get_subfeature_html {
+     return template '/mf/subfeature' => {
+         data => App::API::SubFeature::_read(@_[0]),  # pass along $ctx
+     };
+ }
+
+This article series concludes with a scheme for
+L<hot code reloading|/2015/8>, a very useful feature in any Dancer
+app, but especially helpful as your app grows larger.

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -161,7 +161,9 @@ The only other thing to change here is that REST APIs normally return
 JSON or XML. I prefer JSON since that's directly usable by the
 JavaScript code that made the Ajax call to one of these APIs. One of the
 best features of Dancer is that automatic JSON encoding is built right
-in. First, enable the feature by adding this to your C<config.yml> file:
+in.
+
+First, enable the feature by adding this to your C<config.yml> file:
 
     serializer: JSON
 
@@ -188,7 +190,7 @@ That lets us write the C<_create()> function referenced above as:
 By telling Dancer that we want unlabeled return values from route
 handlers to be sent through the built-in JSON serializer, it not only
 converts Perl data structures to their JSON equivalents, it also
-automatically sets the the HTTP response's content type is set to
+automatically sets the response's HTTP C<Content-Type> header to
 C<application/json>. Parsing and using that reply on the client side in
 JavaScript is therefore trivial.
 

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -6,11 +6,11 @@ In previous parts of L<this article series|/2015/3>, I defined each
 route handler as a one-liner, like so:
 
     prefix '/mf' => sub {
-        get '/' => \&retrieve;
+        get '' => \&retrieve;
         prefix '/subfeature' => sub {
-            get  '/'    => \&_get;
-            post '/'    => \&_post;
-            put  '/'    => \&_put;
+            get  ''     => \&_get;
+            post ''     => \&_post;
+            put  ''     => \&_put;
             del  '/:id' => \&_del;
         };
     };
@@ -125,8 +125,8 @@ a bit:
 
     prefix '/api' => sub {
         prefix '/subfeature' => sub {
-            post '/'    => \&_post;
-            get  '/'    => \&_get;
+            post ''     => \&_post;
+            get  ''     => \&_get;
             put  '/:id' => \&_put;
             del  '/:id' => \&_del;
         };
@@ -140,8 +140,8 @@ You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
 
     prefix '/api' => sub {
         prefix '/subfeature' => sub {
-            post '/'    => \&_create;
-            get  '/'    => \&_read;
+            post ''     => \&_create;
+            get  ''     => \&_read;
             put  '/:id' => \&_update;
             del  '/:id' => \&_delete;
         };

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -214,7 +214,7 @@ explicitly marked. If your application returns HTML more often than
 JSON, this may seem backwards. Wouldn't it be simpler to leave the
 default serializer unset, so that C<template> calls and such return
 normally, and mark the JSON-returning API route handlers explicitly
-instead via C<send_as JSON =E<gt>...>?
+instead via C<send_as JSON =E<gt> ...>?
 
 You could indeed do that, but then you lose a nice side benefit of this
 arrangement: it makes it easy to define parallel route handlers for
@@ -242,10 +242,15 @@ Consider this addition to the route handlers defined above:
 Briefly, what this does is define a C</parts> route hierarchy that is
 parallel to the C</api> hierarchy, with the former implemented in terms
 of the latter. That is, the application's API returns JSON, and the
-applications "parts" subsystem returns HTML fragments that present the
-same data the JSON APIs return but in HTML form.
+applications "parts" subsystem returns HTML renditions of the same data
+returned by the JSON API. This works because the API route handlers are
+defined to return raw Perl data structures, which we can consume
+directly from other route handlers as above, or let Dancer render them
+to JSON when those route handlers are called by a web client.
 
-Then you can include one of those parts inside a complete HTML page:
+While you could consume these HTML fragments ("parts") via Ajax, you can
+also save an HTTP round trip by textually including them into complete
+web pages assembled by Dancer's template mechanism:
 
     package App::MajorFeature::SubFeature
     use Dancer2 appname => 'App';
@@ -264,7 +269,11 @@ Then you can include one of those parts inside a complete HTML page:
         };
     };
 
-Now we have three different ways to get the same data: as part of a
+The C</views/mf/sf.tt> template can then reference C<part> to insert the
+HTML fragment into the larger web page, without duplicating the HTML
+code for that fragment.
+
+This gives us three different ways to get the same data: as part of a
 complete web page (C<GET /mf/sf>), as an HTML fragment that we can
 insert into an existing web page via Ajax on the browser side or textual
 inclusion on the Dancer side (C<GET /parts/mf/sf>), and as raw JSON data

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -279,26 +279,18 @@ insert into an existing web page via Ajax on the browser side or textual
 inclusion on the Dancer side (C<GET /parts/mf/sf>), and as raw JSON data
 that we could process on the browser side (C<GET /api/mf/sf>).
 
-This layered design pattern is common in code that needs to return an
-initial view of a given data structure which is later updated via Ajax.
-The initial page load pre-renders the raw data on the Dancer side by
-calling down into its own C<App::Parts> route handler, textually
-including the returned HTML fragment into the larger HTML page. Then as
-dynamic events happen on the browser side, the JavaScript code handling
-those events can either fetch a new rendering of the data by calling
-back to the C</parts> route handler that serves up that HTML fragment,
-or it can get the same data in JSON form via an C</api> call.
-
-This design has two additional benefits besides avoiding a violation of the
+This layered design pattern has two additional benefits besides avoiding
+violations of the
 L<DRY principle|https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>:
 
-First, it saves one HTTP round trip on the initial request over the
-common alternative design, where the server simply returns an empty HTML
-container which must be filled by JavaScript code with a subsequent
-JavaScript Ajax call; HTTP round-trips are usually expensive enough to
-add human-scale amounts of delay to your web app's response time, so any
-time you spend to remove unnecessary round-trips usually pays immediate
-tangible benefits.
+First, textually including an HTML rendering of the raw data on the
+server side as part of the initial HTTP page load saves an HTTP round
+trip over the common alternative design, where the server simply returns
+an empty HTML container which must be filled by JavaScript code with a
+subsequent JavaScript Ajax call. HTTP round-trips are usually expensive
+enough to add human-scale amounts of delay to your web app's response
+time, so any time you spend to remove unnecessary round-trips usually
+pays immediate tangible benefits.
 
 Second, this design ensures that your web app returns an initial HTML
 view of the data even to clients not running JavaScript. Even if you can

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -37,7 +37,7 @@ This practice of defining Dancer route handlers as one-liners solves
 that. It ensures that every time you adjust the route handlers for your
 site, you're doing so while looking at the neighboring routes; you will
 be defining new routes in context, not independently. This counteracts
-the entropic forces that result in API design drift, because it
+the entropic forces that result in API design drift because it
 implicitly encourages you to define new routes that fit logically into
 the scheme you defined previously. Without this extra Perl function call
 layer, the route definitions are visually broken up, so that you cannot
@@ -70,7 +70,7 @@ you of? If you said
 L<CRUD|https://en.wikipedia.org/wiki/Create,_read,_update_and_delete>,
 go to the head of the class.
 
-Now, HTTP verbs do not correspond directly to CRUD, because HTTP was not
+Now, HTTP verbs do not correspond directly to CRUD because HTTP was not
 designed to be a CRUD API. There are competing design philosophies when
 it comes to mapping HTTP verbs to the CRUD model of persistent data
 storage.
@@ -92,14 +92,14 @@ defines C<POST> and C<PUT> so that they're nearly interchangeable, which
 is how we ended up with competing REST/CRUD API design philosophies.
 
 Some web API designers like to use C<POST> for both create and update
-operations, since you can distinguish the cases based on whether the
+operations since you can distinguish the cases based on whether the
 HTTP request contains a database row ID: if so, it's a request to update
 an existing record, else it's a record creation request.
 
 That justification is fine in a web framework that defines the URL
-scheme in the file system, such as PHP, ASP, or JSP, since it is normal
+scheme in the file system, such as PHP, ASP, or JSP since it is normal
 to handle all four verbs in a single file in that sort of web framework.
-In Dancer, my preferred scheme works better, since it defines one route
+In Dancer, my preferred scheme works better since it defines one route
 per CRUD operation.
 
 Although the HTTP spec defines C<PUT> and C<POST> as partially
@@ -148,11 +148,11 @@ You might instead prefer to make the HTTP-to-CRUD mapping more explicit:
  };
 
 As in the previous article in this series, the leading underscore
-convention saves us some aggravation here, since C<delete> is a Perl
+convention saves us some aggravation here since C<delete> is a Perl
 keyword, and C<read> is a core Perl function.
 
 The only other thing to change here is that REST APIs normally return
-JSON or XML. I prefer JSON, since that's directly usable by the
+JSON or XML. I prefer JSON since that's directly usable by the
 JavaScript code that made the Ajax call to one of these APIs. One of the
 best features of Dancer is that automatic JSON encoding is built right
 in. We might define the C<_create()> function referenced above as:

--- a/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
+++ b/danceradvent/public/articles/2015/7-medium-scale-part-5.pod
@@ -109,7 +109,7 @@ L<C<PUT> is idempotent|http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec
 that the browser is allowed to cache C<PUT> requests, suppressing
 subsequent identical calls if the request parameters do not change. In
 CRUD terms, this means that if you define "create" in terms of C<PUT>,
-the browser mignt not let you create two records with identical
+the browser might not let you create two records with identical
 contents but different IDs, which means you risk losing data. The HTTP
 spec does not allow browsers to assume that identical C<POST> calls are
 idempotent, however, so we use that verb for CRUD's create operation,

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -162,3 +162,8 @@ by following some sensible naming conventions.
 
 I hope this reduces some of the growing pains in your own Dancer
 applications!
+
+=head2 Copyright
+
+© 2015, 2016 by Educational Technology Resources, licensed under
+L<Creative Commons Attribution-ShareAlike 4.0|http://creativecommons.org/licenses/by-sa/4.0/>

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -44,7 +44,7 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
          delete $INC{$module};
          eval {
              # Suppress complaints about sub redefinition
-             no warnings 'redefine'; <br />
+             no warnings 'redefine';
              local $SIG{__WARN__} = sub {};
  
              # Reload the module, unloaded above
@@ -55,7 +55,7 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
              $g_module_times{$module} = $mt;
          };
          error "Reloading changed module $module: $@!" if $@;
-     } <br />
+     }
  }
  
  1;

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -48,7 +48,7 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
          delete $INC{$module};
          eval {
              # Suppress complaints about sub redefinition
-             no warnings 'redefine';  ## no critic
+             no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
              local $SIG{__WARN__} = sub {};
  
              # Reload the module, unloaded above
@@ -57,9 +57,16 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
  
              # Only mark it updated if that didn't throw an exception.
              $g_module_times{$module} = $mt;
-         };
-         error "Reloading changed module $module: $@!" if $@;
+
+             # Return true to skip exception hnandler
+             1;
+         }
+         or do {
+             error "Failed to reload changed module $module: $@!";
+         }
      }
+
+     return;
  }
  
  1;

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -19,64 +19,64 @@ solutions.
 Consider this Dancer-aware reloader based on Hack 30 in
 L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
 
-	 package App::Reloader;
+    package App::Reloader;
 
-	 use strict;
-	 use warnings;
+    use strict;
+    use warnings;
 
-	 use Dancer2 appname => 'App';
-	 
-	 my $g_last_reload_check_time = 0;
-	 my %g_module_times;
-	 my %g_min_check_rate = 1;
-	 
-	 INIT {
-		 while (my ($module, $path) = each %INC) {
-			 $g_module_times{$module} = -M $path;
-		 }
-	 }
+    use Dancer2 appname => 'App';
+     
+    my $g_last_reload_check_time = 0;
+    my %g_module_times;
+    my %g_min_check_rate = 1;
+     
+    INIT {
+        while (my ($module, $path) = each %INC) {
+            $g_module_times{$module} = -M $path;
+        }
+    }
 
-	 sub import {   
-		 my ($module, %params) = @_;
-		 $g_min_check_rate = $params{rate} if exists $params{rate};
-	 }       
-	 
-	 sub check {
-		 my $now = time;
-		 return if ($now - $g_last_reload_check_time) < $g_min_check_rate;
-		 $g_last_reload_check_time = $now;
-	 
-		 while (my ($module, $time) = each %g_module_times) {
-			 my $mt = -M $INC{$module};
-			 next if $mt == $time;                   # module hasn't changed
-			 next if $module eq 'App/Const.pm';      # can't redefine constants
-			 next if $module eq 'App/Reloader.pm';   # self-reload breaks things
-	 
-			 delete $INC{$module};
-			 eval {
-				 # Suppress complaints about subroutine redefinition
-				 no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
-				 local $SIG{__WARN__} = sub {};
-	 
-				 # Reload the module, unloaded above
-				 require $module;
-				 debug "Reloaded changed module $module.";
-	 
-				 # Only mark it updated if that didn't throw an exception.
-				 $g_module_times{$module} = $mt;
+    sub import {   
+        my ($module, %params) = @_;
+        $g_min_check_rate = $params{rate} if exists $params{rate};
+    }       
+     
+    sub check {
+        my $now = time;
+        return if ($now - $g_last_reload_check_time) < $g_min_check_rate;
+        $g_last_reload_check_time = $now;
+    
+        while (my ($module, $time) = each %g_module_times) {
+            my $mt = -M $INC{$module};
+            next if $mt == $time;                   # module hasn't changed
+            next if $module eq 'App/Const.pm';      # can't redefine constants
+            next if $module eq 'App/Reloader.pm';   # self-reload breaks things
+    
+            delete $INC{$module};
+            eval {
+                # Suppress complaints about subroutine redefinition
+                no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
+                local $SIG{__WARN__} = sub {};
+    
+                # Reload the module, unloaded above
+                require $module;
+                debug "Reloaded changed module $module.";
+    
+                # Only mark it updated if that didn't throw an exception.
+                $g_module_times{$module} = $mt;
 
-				 # Return true to skip exception hnandler
-				 1;
-			 }
-			 or do {
-				 error "Failed to reload changed module $module: $@!";
-			 }
-		 }
+                # Return true to skip exception hnandler
+                1;
+            }
+            or do {
+                error "Failed to reload changed module $module: $@!";
+            }
+        }
 
-		 return;
-	 }
-	 
-	 1;
+        return;
+    }
+    
+    1;
 
 You also need to merge the following into the module containing your
 Dancer hooks, C<lib/App.pm> by default:

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -18,6 +18,10 @@ Consider this Dancer-aware reloader based on Hack 30 in
 L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
 
  package App::Reloader;
+
+ use strict;
+ use warnings;
+
  use Dancer2 appname => 'App';
  
  my $g_last_reload_check_time = 0;
@@ -44,7 +48,7 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
          delete $INC{$module};
          eval {
              # Suppress complaints about sub redefinition
-             no warnings 'redefine';
+             no warnings 'redefine';  ## no critic
              local $SIG{__WARN__} = sub {};
  
              # Reload the module, unloaded above

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -28,28 +28,33 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
  
  my $g_last_reload_check_time = 0;
  my %g_module_times;
+ my %g_min_check_rate = 1;
  
  INIT {
      while (my ($module, $path) = each %INC) {
          $g_module_times{$module} = -M $path;
      }
  }
+
+ sub import {   
+     my ($module, %params) = @_;
+     $g_min_check_rate = $params{rate} if exists $params{rate};
+ }       
  
- sub reload {
-     my ($min_delta) = @_;
+ sub check {
      my $now = time;
-     return if ($now - $g_last_reload_check_time) < $min_delta;
+     return if ($now - $g_last_reload_check_time) < $g_min_check_rate;
      $g_last_reload_check_time = $now;
  
      while (my ($module, $time) = each %g_module_times) {
          my $mt = -M $INC{$module};
-         next if $mt == $time;
+         next if $mt == $time;                   # module hasn't changed
          next if $module eq 'App/Const.pm';      # can't redefine constants
          next if $module eq 'App/Reloader.pm';   # self-reload breaks things
  
          delete $INC{$module};
          eval {
-             # Suppress complaints about sub redefinition
+             # Suppress complaints about subroutine redefinition
              no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
              local $SIG{__WARN__} = sub {};
  
@@ -76,16 +81,14 @@ L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
 You also need to merge the following into the module containing your
 Dancer hooks, C<lib/App.pm> by default:
 
- use App::Reloader;
- use Readonly;
- 
- Readonly::Scalar my $min_reload_check_time =>
+ use Dancer2 appname => 'App';
+ use App::Reloader rate =>
      (config->{environment} eq 'development' ? 1 : 15);
  
  hook before => sub {
      # do checks that cause an immediate client rejection first
  
-     App::Reloader::reload($min_reload_check_time);
+     App::Reloader::check;
  
      # now we can do other stuff that requires up-to-date modules
  };
@@ -114,7 +117,7 @@ last hit are still good. The example above checks at most once a second
 in development mode, and once every 15 seconds in production. You can
 adjust the timing to suit your purposes.
 
-C<Module::Reload> exposes a C<check()> function similar to C<reload()>
+C<Module::Reload> exposes a C<check()> function similar to our C<check()>
 above, so you could wrap it in your own timing logic, but I've moved
 that internal to the reloader, so you only need to pass in the time
 constant.
@@ -146,7 +149,7 @@ excluding every module that defines a constant. If you scatter
 C<Readonly> calls throughout your other modules instead, they'll be
 un-reloadable, too.
 
-=head2 Series Conclusion
+=head1 Series Conclusion
 
 Well, that's it, the end of
 L<this article series|http://advent.perldancer.org/2015/3>. We have gone

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -1,0 +1,148 @@
+=head1 Medium-Scale Dancer, Part 6: Hot Code Reloading
+
+Many other web frameworks have a hot code reloading feature: simply by
+changing a source file on disk, the new code in that file runs for each
+subsequent web hit that calls that code. This makes development quicker
+by reducing the reload time in the edit/reload/test/debug cycle.
+
+Dancer does not include this feature out of the box, but the power of
+Perl makes it fairly easy to add to your app.
+
+There are, in fact, numerous CPAN modules to do this already, such as
+C<Module::Reload>, but it turns out that rolling your own can provide
+some serious benefits. There are details you want to take care of
+manually during the reloading process which rule out the canned
+solutions.
+
+Consider this Dancer-aware reloader based on Hack 30 in
+L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
+
+ package App::Reloader;
+ use Dancer2 appname => 'App';
+ 
+ my $g_last_reload_check_time = 0;
+ my %g_module_times;
+ 
+ INIT {
+     while (my ($module, $path) = each %INC) {
+         $g_module_times{$module} = -M $path;
+     }
+ }
+ 
+ sub reload {
+     my ($min_delta) = @_;
+     my $now = time;
+     return if ($now - $g_last_reload_check_time) < $min_delta;
+     $g_last_reload_check_time = $now;
+ 
+     while (my ($module, $time) = each %g_module_times) {
+         my $mt = -M $INC{$module};
+         next if $mt == $time;
+         next if $module eq 'App/Const.pm';      # can't redefine constants
+         next if $module eq 'App/Reloader.pm';   # self-reload breaks things
+ 
+         delete $INC{$module};
+         eval {
+             # Suppress complaints about sub redefinition
+             no warnings 'redefine'; <br />
+             local $SIG{__WARN__} = sub {};
+ 
+             # Reload the module, unloaded above
+             require $module;
+             debug "Reloaded changed module $module.";
+ 
+             # Only mark it updated if that didn't throw an exception.
+             $g_module_times{$module} = $mt;
+         };
+         error "Reloading changed module $module: $@!" if $@;
+     } <br />
+ }
+ 
+ 1;
+
+You also need to merge the following into the module containing your
+Dancer hooks, C<lib/App.pm> by default:
+
+ use App::Reloader;
+ use Readonly;
+ 
+ Readonly::Scalar my $min_reload_check_time =>
+     (config->{environment} eq 'development' ? 1 : 15);
+ 
+ hook before => sub {
+     # do checks that cause an immediate client rejection first
+ 
+     App::Reloader::reload($min_reload_check_time);
+ 
+     # now we can do other stuff that requires up-to-date modules
+ };
+
+This mechanism gives us a number of features you don't get from the
+canned solutions:
+
+=head2 Logging
+
+We can use Dancer's logging mechanism to report what the reloader is
+doing.
+
+Third-party loaders are typically either silent, which makes debugging
+more difficult, or they use the C<STDOUT> or C<STDERR> streams. Using
+C<STDOUT> with Dancer is a serious problem, since that ends up injecting
+the message into the rendered route output, which typically breaks its
+client-side handling. Using C<STDERR> isn't much better, since your
+Dancer app typically runs in the background; unless you redirect the
+app's C<STDERR> to a second log file, you won't see these complaints.
+
+=head2 Performance
+
+Our custom reloader needn't check for reloadable modules on every web
+hit. Chances are, the code we loaded from the modules on disk for the
+last hit are still good. The example above checks at most once a second
+in development mode, and once every 15 seconds in production. You can
+adjust the timing to suit your purposes.
+
+C<Module::Reload> exposes a C<check()> function similar to C<reload()>
+above, so you could wrap it in your own timing logic, but I've moved
+that internal to the reloader, so you only need to pass in the time
+constant.
+
+Other reloaders add a constant burden to the system, so they're
+recommended only for development. While reloaders are exceedingly useful
+during development, it's also nice to be able to do an app upgrade in
+production without restarting the app. We therefore want a reloader that
+we aren't reluctant to run full-time.
+
+=head2 Easy Exclusions
+
+In L<the first article in this series|http://advent.perldancer.org/2015/3>,
+I proposed that you might want an C<App::Const> module for holding
+app-wide constants. If you use the CPAN module C<Readonly>, demonstrated
+above, you will find that you get an error from Perl about redefining
+constants if you let C<App::Reloader> reload that file. We need to make
+the reloader aware of this.
+
+Generic reloaders typically won't cope with cases like this, or they
+expose a somewhat clumsy API for customizing the set of modules it
+monitors. It's simpler to just add an exclusion rule to this file when
+you come across a module that can't be reloaded for one reason or
+another.
+
+Now you know why I recommend collecting app-wide constants into a single
+module: we only need to make one exclusion to handle this, instead of
+excluding every module that defines a constant. If you scatter
+C<Readonly> calls throughout your other modules instead, they'll be
+un-reloadable, too.
+
+=head2 Series Conclusion
+
+Well, that's it, the end of
+L<this article series|http://advent.perldancer.org/2015/3>. We have gone
+from a monolithic app structure as generated by C<dancer2 -a App> to a
+nicely-factored application that's ready to grow into the thousands of
+lines of code. Along the way, we discovered that we had a REST API
+sitting there in our app's URL structure all along, and matched up the
+rest of the URLs to resources in a way that will make debugging simpler
+by following some sensible naming conventions.
+
+I hope this reduces some of the growing pains in your own Dancer
+applications!

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -146,7 +146,7 @@ another.
 Now you know why I recommend collecting app-wide constants into a single
 module: we only need to make one exclusion to handle this, instead of
 excluding every module that defines a constant. If you scatter
-C<Readonly> calls throughout your other modules instead, they'll be
+C<Readonly> calls throughout your other modules instead, they will be
 un-reloadable, too.
 
 =head1 Series Conclusion

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -19,79 +19,79 @@ solutions.
 Consider this Dancer-aware reloader based on Hack 30 in
 L<Perl Hacks|http://shop.oreilly.com/product/9780596526740.do>:
 
- package App::Reloader;
+	 package App::Reloader;
 
- use strict;
- use warnings;
+	 use strict;
+	 use warnings;
 
- use Dancer2 appname => 'App';
- 
- my $g_last_reload_check_time = 0;
- my %g_module_times;
- my %g_min_check_rate = 1;
- 
- INIT {
-     while (my ($module, $path) = each %INC) {
-         $g_module_times{$module} = -M $path;
-     }
- }
+	 use Dancer2 appname => 'App';
+	 
+	 my $g_last_reload_check_time = 0;
+	 my %g_module_times;
+	 my %g_min_check_rate = 1;
+	 
+	 INIT {
+		 while (my ($module, $path) = each %INC) {
+			 $g_module_times{$module} = -M $path;
+		 }
+	 }
 
- sub import {   
-     my ($module, %params) = @_;
-     $g_min_check_rate = $params{rate} if exists $params{rate};
- }       
- 
- sub check {
-     my $now = time;
-     return if ($now - $g_last_reload_check_time) < $g_min_check_rate;
-     $g_last_reload_check_time = $now;
- 
-     while (my ($module, $time) = each %g_module_times) {
-         my $mt = -M $INC{$module};
-         next if $mt == $time;                   # module hasn't changed
-         next if $module eq 'App/Const.pm';      # can't redefine constants
-         next if $module eq 'App/Reloader.pm';   # self-reload breaks things
- 
-         delete $INC{$module};
-         eval {
-             # Suppress complaints about subroutine redefinition
-             no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
-             local $SIG{__WARN__} = sub {};
- 
-             # Reload the module, unloaded above
-             require $module;
-             debug "Reloaded changed module $module.";
- 
-             # Only mark it updated if that didn't throw an exception.
-             $g_module_times{$module} = $mt;
+	 sub import {   
+		 my ($module, %params) = @_;
+		 $g_min_check_rate = $params{rate} if exists $params{rate};
+	 }       
+	 
+	 sub check {
+		 my $now = time;
+		 return if ($now - $g_last_reload_check_time) < $g_min_check_rate;
+		 $g_last_reload_check_time = $now;
+	 
+		 while (my ($module, $time) = each %g_module_times) {
+			 my $mt = -M $INC{$module};
+			 next if $mt == $time;                   # module hasn't changed
+			 next if $module eq 'App/Const.pm';      # can't redefine constants
+			 next if $module eq 'App/Reloader.pm';   # self-reload breaks things
+	 
+			 delete $INC{$module};
+			 eval {
+				 # Suppress complaints about subroutine redefinition
+				 no warnings 'redefine';  ## no critic (ProhibitNoWarnings)
+				 local $SIG{__WARN__} = sub {};
+	 
+				 # Reload the module, unloaded above
+				 require $module;
+				 debug "Reloaded changed module $module.";
+	 
+				 # Only mark it updated if that didn't throw an exception.
+				 $g_module_times{$module} = $mt;
 
-             # Return true to skip exception hnandler
-             1;
-         }
-         or do {
-             error "Failed to reload changed module $module: $@!";
-         }
-     }
+				 # Return true to skip exception hnandler
+				 1;
+			 }
+			 or do {
+				 error "Failed to reload changed module $module: $@!";
+			 }
+		 }
 
-     return;
- }
- 
- 1;
+		 return;
+	 }
+	 
+	 1;
 
 You also need to merge the following into the module containing your
 Dancer hooks, C<lib/App.pm> by default:
 
- use Dancer2 appname => 'App';
- use App::Reloader rate =>
-     (config->{environment} eq 'development' ? 1 : 15);
- 
- hook before => sub {
-     # do checks that cause an immediate client rejection first
- 
-     App::Reloader::check;
- 
-     # now we can do other stuff that requires up-to-date modules
- };
+    use Dancer2 appname => 'App';
+    use App::Reloader rate =>
+        (config->{environment} eq 'development' ? 1 : 15);
+    
+    hook before => sub {
+        # do checks that cause an immediate client rejection first
+    
+        App::Reloader::check;
+    
+        # now we can do other stuff that requires up-to-date modules
+    };
 
 This mechanism gives us a number of features you don't get from the
 canned solutions:

--- a/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
+++ b/danceradvent/public/articles/2015/8-medium-scale-part-6.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Medium-Scale Dancer, Part 6: Hot Code Reloading
 
 Many other web frameworks have a hot code reloading feature: simply by


### PR DESCRIPTION
I chose to insert these articles starting on December 3, to leave the first two spots for the introductory and "state of Dancer" articles I see in past years. Beware that if you move this series within the month that there are several hyperlinks interconnecting these articles that need to be updated, too.

Incidentally, the shuffled grid view of the articles breaks the continuity of the series. Maybe for 2015, the grid could change to a proper calendar view, with leading cells skipped so that December 1 appears in the Tuesday column in 2015.
