### PR TITLE
Create an /archive route

### DIFF
--- a/danceradvent/cpanfile
+++ b/danceradvent/cpanfile
@@ -1,0 +1,5 @@
+requires "Dancer2";
+requires "Pod::POM";
+requires "Text::Outdent";
+requires "Dancer::Plugin::Feed";
+requires "Dancer::Plugin::MobileDevice";

--- a/danceradvent/views/archive.tt
+++ b/danceradvent/views/archive.tt
@@ -1,0 +1,18 @@
+
+<h1>Perl Dancer Advent Calendar Archive</h1>
+
+[% IF all_entries.size %]
+    <h2>Full article list</h2>
+    <p>
+    Here's a full list of the previous posts with their titles:
+    </p>
+    <ul>
+    [% use Dumper %]
+    [% FOR a IN all_entries %]
+        [% next UNLESS a.year %]
+        <li><a href="[% a.year %]/[% a.issued.day %]">[% a.title %]</a> ([% a.year %])</li>
+    [% END %]
+    </ul>
+[% END %]
+
+

--- a/danceradvent/views/layouts/main.tt
+++ b/danceradvent/views/layouts/main.tt
@@ -36,13 +36,18 @@ Each day of December until Christmas, one article about Dancer. Stay tuned for n
 
 <ul id="sidebar-items">
 <li>
+    <h3>Archive/RSS Feed</h3>
+    <ul class="links">
+      <li><a href="[% uri_base %]/archive">Archive of all articles</a>
+      <li><a class="feed" href="[% uri_base %]/feed/[% year %]">[% year %] RSS Feed</a></li>
+    </ul>
     <h3>About Dancer</h3>
     <ul class="links">
         <li><a href="http://www.perldancer.org/">Dancer homepage</a></li>
         <li><a href="http://twitter.com/PerlDancer">Official Twitter</a></li>
         <li><a href="http://github.com/PerlDancer/Dancer">Dancer on GitHub</a></li>
         <li><a href="http://github.com/PerlDancer/Dancer2">Dancer 2 on GitHub</a></li>
-        <li><a class="feed" href="[% uri_base %]/feed/[% year %]">RSS</a></li>
+        
     </ul>
 </li>
 </ul>


### PR DESCRIPTION
When spinning up a new Dancer2 project and googling for things I found myself on the Advent site and wanting to be able to more easily find old articles.

This PR adds an /archive route which re-uses existing code to get all the articles for previous years and presents them in a list.

This should mean that scanning by eye is easier and CTRL+F to find things is practical.

I make a cosmetic change to the RSS feed link also.

Lastly, I included a cpanfile just in case it's useful, it was created as I tried to get the site running locally.


I did mess with the year of the return data in the private sub. I could revert that; or if welcome continue the process and remove the use of global param.