### PR TITLE
Replace Google Analytics with Plausible

### DIFF
--- a/danceradvent/views/layouts/main.tt
+++ b/danceradvent/views/layouts/main.tt
@@ -18,6 +18,7 @@
 <link href="/css/prettify.css" type="text/css" rel="stylesheet" />
 <script type="text/javascript" src="/javascripts/prettify.js"></script>
 
+<script defer data-domain="advent.perldancer.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body onload="prettyPrint()">
 <div id="page">
@@ -67,18 +68,6 @@ Dancer Perl web framework</a>
 </div>
 </div>
 
-
-<script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-25174467-2']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
 
 </script>
 </body>


### PR DESCRIPTION
Google retired Universal Analytics at the end of June, so we weren't collecting stats anyhow. Plausible is less invasive, more privacy friendly, based in the EU, and plays nicely with CA and EU regulations.